### PR TITLE
feat: JSONPointer from JSONPathMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Changed the `JSONPathMatch.parts` representation of the non-standard _keys_ selector (default `~`) to be `~` followed by the key name. It used to be two "parts", `~` and key index.
 
+**Fixes**
+
+- Changed `findall()` and `finditer()` to accept `data` arguments of any `io.IOBase` subclass, not just `TextIO`.
+
 **Features**
 
 - Added the `JSONPointer` class and methods for converting a `JSONPathMatch` to a `JSONPointer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Features**
 
 - Added the `JSONPointer` class and methods for converting a `JSONPathMatch` to a `JSONPointer`.
+- Added `jsonpath.resolve()`, a convenience function for resolving a [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901).
 - All selectors now use `env.match_class` to instantiate new `JSONPathMatch` objects. This allows for subclassing of `JSONPathMatch`.
 
 ## Version 0.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Python JSONPath Change Log
 
+## Version 0.8.0 (unreleased)
+
+**Breaking changes**
+
+- Changed the `JSONPathMatch.parts` representation of the non-standard _keys_ selector (default `~`) to be `~` followed by the key name. It used to be two "parts", `~` and key index.
+
+**Features**
+
+- Added the `JSONPointer` class and methods for converting a `JSONPathMatch` to a `JSONPointer`.
+- All selectors now use `env.match_class` to instantiate new `JSONPathMatch` objects. This allows for subclassing of `JSONPathMatch`.
+
 ## Version 0.7.1
 
 **Fixes**

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,4 @@
 # API Reference
-
 ::: jsonpath.JSONPathEnvironment
     handler: python
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,3 +11,6 @@
 
 ::: jsonpath.CompoundJSONPath
     handler: python
+
+::: jsonpath.JSONPointer
+    handler: python

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -135,7 +135,7 @@ other_users = path.findall(other_data)
 
 ## `resolve(pointer, data)`
 
-Resolve a [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901). A JSON Pointer references a single object on a specific "path" in a JSON document. Here, _pointer_ must be a string representation of a JSON Pointer and _data_ can be a file-like object or string containing JSON formatted data, or equivalent Python objects.
+Resolve a [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901). A JSON Pointer references a single object on a specific "path" in a JSON document. Here, _pointer_ can be a string representation of a JSON Pointer, or a list of parts that make up a pointer. _data_ can be a file-like object or string containing JSON formatted data, or equivalent Python objects.
 
 ```python
 import jsonpath
@@ -163,6 +163,9 @@ data = {
 
 sue_score = jsonpath.resolve("/users/0/score", data)
 print(sue_score)  # 100
+
+jane_score = jsonpath.resolve(["users", 3, "score"], data)
+print(jane_score)  # 55
 ```
 
 If the pointer can't be resolved against the target JSON document - due to missing keys/properties or out of range indices - a `JSONPointerIndexError`, `JSONPointerKeyError` or `JSONPointerTypeError` will be raised, each of which inherit from `JSONPointerResolutionError`. A default value can be given, which will be returned in the event of a `JSONPointerResolutionError`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -133,6 +133,62 @@ some_users = path.findall(some_data)
 other_users = path.findall(other_data)
 ```
 
+## `resolve(pointer, data)`
+
+Resolve a [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901). A JSON Pointer references a single object on a specific "path" in a JSON document. Here, _pointer_ must be a string representation of a JSON Pointer and _data_ can be a file-like object or string containing JSON formatted data, or equivalent Python objects.
+
+```python
+import jsonpath
+
+data = {
+    "users": [
+        {
+            "name": "Sue",
+            "score": 100,
+        },
+        {
+            "name": "John",
+            "score": 86,
+        },
+        {
+            "name": "Sally",
+            "score": 84,
+        },
+        {
+            "name": "Jane",
+            "score": 55,
+        },
+    ]
+}
+
+sue_score = jsonpath.resolve("/users/0/score", data)
+print(sue_score)  # 100
+```
+
+If the pointer can't be resolved against the target JSON document - due to missing keys/properties or out of range indices - a `JSONPointerIndexError`, `JSONPointerKeyError` or `JSONPointerTypeError` will be raised, each of which inherit from `JSONPointerResolutionError`. A default value can be given, which will be returned in the event of a `JSONPointerResolutionError`.
+
+```python
+import jsonpath
+
+data = {
+    "users": [
+        {
+            "name": "Sue",
+            "score": 100,
+        },
+        {
+            "name": "John",
+            "score": 86,
+        },
+    ]
+}
+
+sue_score = jsonpath.resolve("/users/99/score", data, default=0)
+print(sue_score)  # 0
+```
+
+See also [`JSONPathMatch.pointer()`](api.md#jsonpath.match.JSONPathMatch.pointer), which builds a [`JSONPointer`](api.md#jsonpath.JSONPointer) from a `JSONPathMatch`.
+
 ## What's Next?
 
 Read about user-defined filter functions at [Function Extensions](advanced.md#function-extensions), or see how to make extra data available to filters with [Extra Filter Context](advanced.md#extra-filter-context).

--- a/jsonpath/__init__.py
+++ b/jsonpath/__init__.py
@@ -8,6 +8,8 @@ from .exceptions import JSONPathIndexError
 from .exceptions import JSONPathNameError
 from .exceptions import JSONPathSyntaxError
 from .exceptions import JSONPathTypeError
+from .exceptions import JSONPointerError
+from .exceptions import JSONPointerIndexError
 from .filter import UNDEFINED
 from .lex import Lexer
 from .match import JSONPathMatch
@@ -32,6 +34,8 @@ __all__ = (
     "JSONPathSyntaxError",
     "JSONPathTypeError",
     "JSONPointer",
+    "JSONPointerError",
+    "JSONPointerIndexError",
     "Lexer",
     "Parser",
     "UNDEFINED",

--- a/jsonpath/__init__.py
+++ b/jsonpath/__init__.py
@@ -10,6 +10,9 @@ from .exceptions import JSONPathSyntaxError
 from .exceptions import JSONPathTypeError
 from .exceptions import JSONPointerError
 from .exceptions import JSONPointerIndexError
+from .exceptions import JSONPointerKeyError
+from .exceptions import JSONPointerResolutionError
+from .exceptions import JSONPointerTypeError
 from .filter import UNDEFINED
 from .lex import Lexer
 from .match import JSONPathMatch
@@ -17,6 +20,7 @@ from .parse import Parser
 from .path import CompoundJSONPath
 from .path import JSONPath
 from .pointer import JSONPointer
+from .pointer import resolve
 
 __all__ = (
     "compile",
@@ -36,8 +40,12 @@ __all__ = (
     "JSONPointer",
     "JSONPointerError",
     "JSONPointerIndexError",
+    "JSONPointerKeyError",
+    "JSONPointerResolutionError",
+    "JSONPointerTypeError",
     "Lexer",
     "Parser",
+    "resolve",
     "UNDEFINED",
 )
 

--- a/jsonpath/__init__.py
+++ b/jsonpath/__init__.py
@@ -14,6 +14,7 @@ from .match import JSONPathMatch
 from .parse import Parser
 from .path import CompoundJSONPath
 from .path import JSONPath
+from .pointer import JSONPointer
 
 __all__ = (
     "compile",
@@ -30,6 +31,7 @@ __all__ = (
     "JSONPathNameError",
     "JSONPathSyntaxError",
     "JSONPathTypeError",
+    "JSONPointer",
     "Lexer",
     "Parser",
     "UNDEFINED",

--- a/jsonpath/env.py
+++ b/jsonpath/env.py
@@ -24,6 +24,7 @@ from .exceptions import JSONPathSyntaxError
 from .filter import UNDEFINED
 from .function_extensions import validate
 from .lex import Lexer
+from .match import JSONPathMatch
 from .match import NodeList
 from .parse import Parser
 from .path import CompoundJSONPath
@@ -36,7 +37,6 @@ from .token import Token
 
 if TYPE_CHECKING:
     from .match import FilterContextVars
-    from .match import JSONPathMatch
 
 
 class JSONPathEnvironment:
@@ -106,6 +106,7 @@ class JSONPathEnvironment:
     # Override these to customize path tokenization and parsing.
     lexer_class: Type[Lexer] = Lexer
     parser_class: Type[Parser] = Parser
+    match_class: Type[JSONPathMatch] = JSONPathMatch
 
     def __init__(self) -> None:  # noqa: D107
         self.lexer: Lexer = self.lexer_class(env=self)

--- a/jsonpath/env.py
+++ b/jsonpath/env.py
@@ -14,7 +14,6 @@ from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
-from typing import TextIO
 from typing import Type
 from typing import Union
 
@@ -36,6 +35,8 @@ from .token import TOKEN_UNION
 from .token import Token
 
 if TYPE_CHECKING:
+    from io import IOBase
+
     from .match import FilterContextVars
 
 
@@ -175,7 +176,7 @@ class JSONPathEnvironment:
     def findall(
         self,
         path: str,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         *,
         filter_context: Optional[FilterContextVars] = None,
     ) -> List[object]:
@@ -203,7 +204,7 @@ class JSONPathEnvironment:
     def finditer(
         self,
         path: str,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         *,
         filter_context: Optional[FilterContextVars] = None,
     ) -> Iterable[JSONPathMatch]:
@@ -229,7 +230,7 @@ class JSONPathEnvironment:
     async def findall_async(
         self,
         path: str,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         *,
         filter_context: Optional[FilterContextVars] = None,
     ) -> List[object]:
@@ -241,7 +242,7 @@ class JSONPathEnvironment:
     async def finditer_async(
         self,
         path: str,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         *,
         filter_context: Optional[FilterContextVars] = None,
     ) -> AsyncIterable[JSONPathMatch]:

--- a/jsonpath/exceptions.py
+++ b/jsonpath/exceptions.py
@@ -84,15 +84,19 @@ class JSONPointerEncodeError(JSONPointerError):
     """An exception raised when a JSONPathMatch can't be encoded to a JSON Pointer."""
 
 
-class JSONPointerIndexError(JSONPointerError, IndexError):
+class JSONPointerResolutionError(JSONPointerError):
+    """Base exception for those that can be raised during pointer resolution."""
+
+
+class JSONPointerIndexError(JSONPointerResolutionError, IndexError):
     """An exception raised when an array index is out of range."""
 
 
-class JSONPointerKeyError(JSONPointerError, KeyError):
+class JSONPointerKeyError(JSONPointerResolutionError, KeyError):
     """An exception raised when a pointer references a mapping with a missing key."""
 
 
-class JSONPointerTypeError(JSONPointerError, TypeError):
+class JSONPointerTypeError(JSONPointerResolutionError, TypeError):
     """An exception raised when a pointer resolves a string against a sequence."""
 
 

--- a/jsonpath/exceptions.py
+++ b/jsonpath/exceptions.py
@@ -76,6 +76,18 @@ class JSONPathNameError(JSONPathError):
         self.token = token
 
 
+class JSONPointerError(Exception):
+    """Base class for all JSON Pointer errors."""
+
+
+class JSONPointerEncodeError(JSONPointerError):
+    """An exception raised when a JSONPathMatch can't be encoded to a JSON Pointer."""
+
+
+class JSONPointerIndexError(JSONPointerError):
+    """An exception raised when an array index is out of range."""
+
+
 def _truncate_message(value: str, num: int, end: str = "...") -> str:
     if len(value) < num:
         return value

--- a/jsonpath/exceptions.py
+++ b/jsonpath/exceptions.py
@@ -84,8 +84,16 @@ class JSONPointerEncodeError(JSONPointerError):
     """An exception raised when a JSONPathMatch can't be encoded to a JSON Pointer."""
 
 
-class JSONPointerIndexError(JSONPointerError):
+class JSONPointerIndexError(JSONPointerError, IndexError):
     """An exception raised when an array index is out of range."""
+
+
+class JSONPointerKeyError(JSONPointerError, KeyError):
+    """An exception raised when a pointer references a mapping with a missing key."""
+
+
+class JSONPointerTypeError(JSONPointerError, TypeError):
+    """An exception raised when a pointer resolves a string against a sequence."""
 
 
 def _truncate_message(value: str, num: int, end: str = "...") -> str:

--- a/jsonpath/match.py
+++ b/jsonpath/match.py
@@ -10,7 +10,7 @@ from typing import Tuple
 from typing import Union
 
 FilterContextVars = Mapping[str, Any]
-PathPart = Union[int, slice, str]
+PathPart = Union[int, str]
 
 
 class JSONPathMatch:

--- a/jsonpath/match.py
+++ b/jsonpath/match.py
@@ -9,6 +9,8 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
+from .pointer import JSONPointer
+
 FilterContextVars = Mapping[str, Any]
 PathPart = Union[int, str]
 
@@ -39,6 +41,8 @@ class JSONPathMatch:
         "root",
     )
 
+    pointer_class = JSONPointer
+
     def __init__(
         self,
         *,
@@ -67,6 +71,10 @@ class JSONPathMatch:
     def filter_context(self) -> FilterContextVars:
         """Return filter context data for this match."""
         return self._filter_context
+
+    def pointer(self) -> JSONPointer:
+        """Return a `JSONPointer` pointing to this match's path."""
+        return JSONPointer.from_match(self)
 
 
 def _truncate(val: str, num: int, end: str = "...") -> str:

--- a/jsonpath/path.py
+++ b/jsonpath/path.py
@@ -168,7 +168,7 @@ class JSONPath:
             _data = data
 
         async def root_iter() -> AsyncIterable[JSONPathMatch]:
-            yield JSONPathMatch(
+            yield self.env.match_class(
                 filter_context=filter_context or {},
                 obj=_data,
                 parent=None,

--- a/jsonpath/path.py
+++ b/jsonpath/path.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import itertools
 import json
+from io import IOBase
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import AsyncIterable
@@ -11,7 +12,6 @@ from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
-from typing import TextIO
 from typing import Tuple
 from typing import TypeVar
 from typing import Union
@@ -51,7 +51,7 @@ class JSONPath:
 
     def findall(
         self,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         *,
         filter_context: Optional[FilterContextVars] = None,
     ) -> List[object]:
@@ -77,7 +77,7 @@ class JSONPath:
         """
         if isinstance(data, str):
             _data = json.loads(data)
-        elif isinstance(data, TextIO):
+        elif isinstance(data, IOBase):
             _data = json.loads(data.read())
         else:
             _data = data
@@ -87,7 +87,7 @@ class JSONPath:
 
     def finditer(
         self,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         *,
         filter_context: Optional[FilterContextVars] = None,
     ) -> Iterable[JSONPathMatch]:
@@ -112,7 +112,7 @@ class JSONPath:
         """
         if isinstance(data, str):
             _data = json.loads(data)
-        elif isinstance(data, TextIO):
+        elif isinstance(data, IOBase):
             _data = json.loads(data.read())
         else:
             _data = data
@@ -135,14 +135,14 @@ class JSONPath:
 
     async def findall_async(
         self,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         *,
         filter_context: Optional[FilterContextVars] = None,
     ) -> List[object]:
         """An async version of `findall()`."""
         if isinstance(data, str):
             _data = json.loads(data)
-        elif isinstance(data, TextIO):
+        elif isinstance(data, IOBase):
             _data = json.loads(data.read())
         else:
             _data = data
@@ -155,14 +155,14 @@ class JSONPath:
 
     async def finditer_async(
         self,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         *,
         filter_context: Optional[FilterContextVars] = None,
     ) -> AsyncIterable[JSONPathMatch]:
         """An async version of `finditer()`."""
         if isinstance(data, str):
             _data = json.loads(data)
-        elif isinstance(data, TextIO):
+        elif isinstance(data, IOBase):
             _data = json.loads(data.read())
         else:
             _data = data
@@ -213,7 +213,7 @@ class CompoundJSONPath:
 
     def findall(
         self,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         filter_context: Optional[FilterContextVars] = None,
     ) -> List[object]:
         """Find all objects in `data` matching the given JSONPath `path`.
@@ -250,7 +250,7 @@ class CompoundJSONPath:
 
     def finditer(
         self,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         filter_context: Optional[FilterContextVars] = None,
     ) -> Iterable[JSONPathMatch]:
         """Generate `JSONPathMatch` objects for each match.
@@ -287,7 +287,7 @@ class CompoundJSONPath:
 
     async def findall_async(
         self,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         filter_context: Optional[FilterContextVars] = None,
     ) -> List[object]:
         """An async version of `findall()`."""
@@ -305,7 +305,7 @@ class CompoundJSONPath:
 
     async def finditer_async(
         self,
-        data: Union[str, TextIO, Sequence[Any], Mapping[str, Any]],
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
         filter_context: Optional[FilterContextVars] = None,
     ) -> AsyncIterable[JSONPathMatch]:
         """An async version of `finditer()`."""

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -12,6 +12,9 @@ from typing import Tuple
 from typing import Union
 from urllib.parse import unquote
 
+from .exceptions import JSONPointerEncodeError
+from .exceptions import JSONPointerIndexError
+
 if TYPE_CHECKING:
     from .match import JSONPathMatch
 
@@ -98,8 +101,7 @@ class JSONPointer:
         try:
             index = int(s)
             if index < self.min_int_index or index > self.max_int_index:
-                # TODO: exceptions
-                raise Exception(":(")
+                raise JSONPointerIndexError("index out of range")
             return index
         except ValueError:
             return s
@@ -133,9 +135,8 @@ class JSONPointer:
     def from_match(cls, match: JSONPathMatch, *, strict: bool = True) -> JSONPointer:
         """Return a JSON Pointer for the path from a JSONPathMatch instance."""
         if strict and "~" in match.parts:
-            # TODO: better exception
             # TODO: reference env for current key selector token
-            raise Exception(
+            raise JSONPointerEncodeError(
                 "can't encode a JSON Pointer containing key or index selectors"
             )
 

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -1,0 +1,135 @@
+"""JSON Pointer. See https://datatracker.ietf.org/doc/html/rfc6901."""
+from __future__ import annotations
+
+import codecs
+from functools import reduce
+from operator import getitem
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Mapping
+from typing import Sequence
+from typing import Tuple
+from typing import Union
+from urllib.parse import unquote
+
+if TYPE_CHECKING:
+    from .match import JSONPathMatch
+
+PARTS = Tuple[Union[int, str], ...]
+
+
+class JSONPointer:
+    """A JSON Pointer, as per rfc6901.
+
+    Arguments:
+        s: A string representation of a JSON Pointer.
+        parts: The keys, indices and/or slices that make up a JSONPathMatch. If
+            given, it is assumed that the parts have already been parsed by the
+            JSONPath parser. `unicode_escape` and `uri_decode` are ignored if
+            _parts_ is given.
+        unicode_escape: If `True`, UTF-16 escape sequences will be decoded
+            before parsing the pointer.
+        uri_decode: If `True`, the pointer will be unescaped using _urllib_
+            before being parsed.
+    """
+
+    __slots__ = ("parts", "_s")
+
+    def __init__(
+        self,
+        s: str,
+        *,
+        parts: PARTS = (),
+        unicode_escape: bool = True,
+        uri_decode: bool = False,
+    ) -> None:
+        self.parts = parts or self._parse(
+            s,
+            unicode_escape=unicode_escape,
+            uri_decode=uri_decode,
+        )
+        self._s = s
+
+    def __str__(self) -> str:
+        return self._s
+
+    def _parse(
+        self,
+        s: str,
+        *,
+        unicode_escape: bool,
+        uri_decode: bool,
+    ) -> PARTS:
+        if uri_decode:
+            s = unquote(s)
+
+        if unicode_escape:
+            # UTF-16 escape sequences - possibly surrogate pairs - inside UTF-8
+            # encoded strings. As per https://datatracker.ietf.org/doc/html/rfc4627
+            # section 2.5.
+            s = (
+                codecs.decode(s.replace("\\/", "/"), "unicode-escape")
+                .encode("utf-16", "surrogatepass")
+                .decode("utf-16")
+            )
+
+        parts = tuple(
+            self._index(p.replace("~1", "/").replace("~0", "~")) for p in s.split("/")
+        )
+
+        if parts == ("",):
+            return ()
+        if parts == ("", ""):
+            return ("",)
+        return parts[1:]
+
+    def _index(self, s: str) -> Union[str, int]:
+        try:
+            # TODO: max/min int
+            return int(s)
+        except ValueError:
+            return s
+
+    def resolve(self, obj: Union[Sequence[Any], Mapping[str, Any]]) -> object:
+        """Resolve this pointer against _data_."""
+
+        def _getitem(obj: Any, key: Any) -> Any:
+            try:
+                return getitem(obj, key)
+            except KeyError as err:
+                # Try a string repr of the index-like item as a mapping key.
+                if isinstance(key, int):
+                    try:
+                        return getitem(obj, str(key))
+                    except KeyError:
+                        raise err
+                # TODO: handle non-standard keys selector
+                raise
+            except TypeError as err:
+                if isinstance(obj, Sequence):
+                    try:
+                        return getitem(obj, int(key))
+                    except ValueError:
+                        raise err
+                raise
+
+        return reduce(_getitem, self.parts, obj)
+
+    @classmethod
+    def from_match(cls, match: JSONPathMatch, *, strict: bool = True) -> JSONPointer:
+        """Return a JSON Pointer for the path from a JSONPathMatch instance."""
+        if strict and "~" in match.parts:
+            # TODO: better exception
+            # TODO: reference env for current key selector token
+            raise Exception(
+                "can't encode a JSON Pointer containing key or index selectors"
+            )
+
+        # TODO: use "relative JSON Pointer" style `#` for keys selectors?
+
+        # A rfc6901 string representation of match.parts.
+        s = "/".join(
+            [str(p).replace("~", "~0").replace("/", "~1") for p in match.parts]
+        )
+
+        return cls(s, parts=match.parts, unicode_escape=False, uri_decode=False)

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -27,10 +27,10 @@ _missing = object()
 
 
 class JSONPointer:
-    """A JSON Pointer, as per rfc6901.
+    """A JSON Pointer, as per RFC 6901.
 
     Args:
-        s: A string representation of a JSON Pointer.
+        pointer: A string representation of a JSON Pointer.
         parts: The keys, indices and/or slices that make up a JSON Pointer. If
             given, it is assumed that the parts have already been parsed by the
             JSONPath parser. `unicode_escape` and `uri_decode` are ignored if
@@ -57,18 +57,18 @@ class JSONPointer:
 
     def __init__(
         self,
-        s: str,
+        pointer: str,
         *,
         parts: Tuple[Union[int, str], ...] = (),
         unicode_escape: bool = True,
         uri_decode: bool = False,
     ) -> None:
         self.parts = parts or self._parse(
-            s,
+            pointer,
             unicode_escape=unicode_escape,
             uri_decode=uri_decode,
         )
-        self._s = s
+        self._s = pointer
 
     def __str__(self) -> str:
         return self._s
@@ -159,11 +159,11 @@ class JSONPointer:
 
         Raises:
             JSONPointerIndexError: When attempting to access a sequence by
-                an out of range index.
+                an out of range index, unless a default is given.
             JSONPointerKeyError: If any mapping object along the path does not
-                contain a specified key.
+                contain a specified key, unless a default is given.
             JSONPointerTypeError: When attempting to resolve a non-index string
-                path part against a sequence.
+                path part against a sequence, unless a default is given.
         """
         if isinstance(data, str):
             data = json.loads(data)
@@ -295,11 +295,11 @@ def resolve(
 
     Raises:
         JSONPointerIndexError: When attempting to access a sequence by
-            an out of range index.
+            an out of range index, unless a default is given.
         JSONPointerKeyError: If any mapping object along the path does not contain
-            a specified key.
+            a specified key, unless a default is given.
         JSONPointerTypeError: When attempting to resolve a non-index string path
-            part against a sequence.
+            part against a sequence, unless a default is given.
     """
     if isinstance(pointer, str):
         try:

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -140,7 +140,10 @@ class JSONPointer:
         """Return a JSON Pointer for the path from a JSONPathMatch instance."""
         # A rfc6901 string representation of match.parts.
         return cls(
-            "/".join(str(p).replace("~", "~0").replace("/", "~1") for p in match.parts),
+            "/"
+            + "/".join(
+                str(p).replace("~", "~0").replace("/", "~1") for p in match.parts
+            ),
             parts=match.parts,
             unicode_escape=False,
             uri_decode=False,

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -87,15 +87,9 @@ class JSONPointer:
                 .decode("utf-16")
             )
 
-        parts = tuple(
+        return tuple(
             self._index(p.replace("~1", "/").replace("~0", "~")) for p in s.split("/")
-        )
-
-        if parts == ("",):
-            return ()
-        if parts == ("", ""):
-            return ("",)
-        return parts[1:]
+        )[1:]
 
     def _index(self, s: str) -> Union[str, int]:
         try:

--- a/jsonpath/selectors.py
+++ b/jsonpath/selectors.py
@@ -71,7 +71,7 @@ class PropertySelector(JSONPathSelector):
                 continue
 
             with suppress(KeyError):
-                _match = JSONPathMatch(
+                _match = self.env.match_class(
                     filter_context=match.filter_context(),
                     obj=self.env.getitem(match.obj, self.name),
                     parent=match,
@@ -90,7 +90,7 @@ class PropertySelector(JSONPathSelector):
                 continue
 
             with suppress(KeyError):
-                _match = JSONPathMatch(
+                _match = self.env.match_class(
                     filter_context=match.filter_context(),
                     obj=await self.env.getitem_async(match.obj, self.name),
                     parent=match,
@@ -134,7 +134,7 @@ class IndexSelector(JSONPathSelector):
             if isinstance(match.obj, Mapping):
                 # Try the string representation of the index as a key.
                 with suppress(KeyError):
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=self.env.getitem(match.obj, self._as_key),
                         parent=match,
@@ -147,7 +147,7 @@ class IndexSelector(JSONPathSelector):
             elif isinstance(match.obj, Sequence):
                 norm_index = self._normalized_index(match.obj)
                 with suppress(IndexError):
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=self.env.getitem(match.obj, self.index),
                         parent=match,
@@ -165,7 +165,7 @@ class IndexSelector(JSONPathSelector):
             if isinstance(match.obj, Mapping):
                 # Try the string representation of the index as a key.
                 with suppress(KeyError):
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=await self.env.getitem_async(match.obj, self._as_key),
                         parent=match,
@@ -178,7 +178,7 @@ class IndexSelector(JSONPathSelector):
             elif isinstance(match.obj, Sequence):
                 norm_index = self._normalized_index(match.obj)
                 with suppress(IndexError):
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=await self.env.getitem_async(match.obj, self.index),
                         parent=match,
@@ -201,11 +201,11 @@ class KeysSelector(JSONPathSelector):
     def _keys(self, match: JSONPathMatch) -> Iterable[JSONPathMatch]:
         if isinstance(match.obj, Mapping):
             for i, key in enumerate(match.obj.keys()):
-                _match = JSONPathMatch(
+                _match = self.env.match_class(
                     filter_context=match.filter_context(),
                     obj=key,
                     parent=match,
-                    parts=match.parts + (self.env.keys_selector_token, i),
+                    parts=match.parts + (f"{self.env.keys_selector_token}{key}",),
                     path=f"{match.path}[{self.env.keys_selector_token}][{i}]",
                     root=match.root,
                 )
@@ -269,7 +269,7 @@ class SliceSelector(JSONPathSelector):
             step = self.slice.step or 1
             for obj in self.env.getitem(match.obj, self.slice):
                 norm_index = self._normalized_index(match.obj, idx)
-                _match = JSONPathMatch(
+                _match = self.env.match_class(
                     filter_context=match.filter_context(),
                     obj=obj,
                     parent=match,
@@ -292,7 +292,7 @@ class SliceSelector(JSONPathSelector):
             step = self.slice.step or 1
             for obj in await self.env.getitem_async(match.obj, self.slice):
                 norm_index = self._normalized_index(match.obj, idx)
-                _match = JSONPathMatch(
+                _match = self.env.match_class(
                     filter_context=match.filter_context(),
                     obj=obj,
                     parent=match,
@@ -317,7 +317,7 @@ class WildSelector(JSONPathSelector):
                 continue
             if isinstance(match.obj, Mapping):
                 for key, val in match.obj.items():
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=val,
                         parent=match,
@@ -329,7 +329,7 @@ class WildSelector(JSONPathSelector):
                     yield _match
             elif isinstance(match.obj, Sequence):
                 for i, val in enumerate(match.obj):
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=val,
                         parent=match,
@@ -346,7 +346,7 @@ class WildSelector(JSONPathSelector):
         async for match in matches:
             if isinstance(match.obj, Mapping):
                 for key, val in match.obj.items():
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=val,
                         parent=match,
@@ -358,7 +358,7 @@ class WildSelector(JSONPathSelector):
                     yield _match
             elif isinstance(match.obj, Sequence):
                 for i, val in enumerate(match.obj):
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=val,
                         parent=match,
@@ -382,7 +382,7 @@ class RecursiveDescentSelector(JSONPathSelector):
                 if isinstance(val, str):
                     pass
                 elif isinstance(val, (Mapping, Sequence)):
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=val,
                         parent=match,
@@ -398,7 +398,7 @@ class RecursiveDescentSelector(JSONPathSelector):
                 if isinstance(val, str):
                     pass
                 elif isinstance(val, (Mapping, Sequence)):
-                    _match = JSONPathMatch(
+                    _match = self.env.match_class(
                         filter_context=match.filter_context(),
                         obj=val,
                         parent=match,
@@ -520,7 +520,7 @@ class Filter(JSONPathSelector):
                     )
                     try:
                         if self.expression.evaluate(context):
-                            _match = JSONPathMatch(
+                            _match = self.env.match_class(
                                 filter_context=match.filter_context(),
                                 obj=val,
                                 parent=match,
@@ -546,7 +546,7 @@ class Filter(JSONPathSelector):
                     )
                     try:
                         if self.expression.evaluate(context):
-                            _match = JSONPathMatch(
+                            _match = self.env.match_class(
                                 filter_context=match.filter_context(),
                                 obj=obj,
                                 parent=match,
@@ -583,7 +583,7 @@ class Filter(JSONPathSelector):
                         raise
 
                     if result:
-                        _match = JSONPathMatch(
+                        _match = self.env.match_class(
                             filter_context=match.filter_context(),
                             obj=val,
                             parent=match,
@@ -611,7 +611,7 @@ class Filter(JSONPathSelector):
                             err.token = self.token
                         raise
                     if result:
-                        _match = JSONPathMatch(
+                        _match = self.env.match_class(
                             filter_context=match.filter_context(),
                             obj=obj,
                             parent=match,

--- a/jsonpath/selectors.py
+++ b/jsonpath/selectors.py
@@ -44,7 +44,7 @@ class JSONPathSelector(ABC):
     def resolve_async(
         self, matches: AsyncIterable[JSONPathMatch]
     ) -> AsyncIterable[JSONPathMatch]:
-        """An async version of `expand`."""
+        """An async version of `resolve`."""
 
 
 class PropertySelector(JSONPathSelector):

--- a/jsonpath/selectors.py
+++ b/jsonpath/selectors.py
@@ -17,11 +17,11 @@ from typing import Union
 
 from .exceptions import JSONPathIndexError
 from .exceptions import JSONPathTypeError
-from .match import JSONPathMatch
 
 if TYPE_CHECKING:
     from .env import JSONPathEnvironment
     from .filter import BooleanExpression
+    from .match import JSONPathMatch
     from .token import Token
 
 # ruff: noqa: D102

--- a/jsonpath/selectors.py
+++ b/jsonpath/selectors.py
@@ -138,7 +138,7 @@ class IndexSelector(JSONPathSelector):
                         filter_context=match.filter_context(),
                         obj=self.env.getitem(match.obj, self._as_key),
                         parent=match,
-                        parts=match.parts + (self.index,),
+                        parts=match.parts + (self._as_key,),
                         path=f"{match.path}['{self.index}']",
                         root=match.root,
                     )
@@ -169,7 +169,7 @@ class IndexSelector(JSONPathSelector):
                         filter_context=match.filter_context(),
                         obj=await self.env.getitem_async(match.obj, self._as_key),
                         parent=match,
-                        parts=match.parts + (self.index,),
+                        parts=match.parts + (self._as_key,),
                         path=f"{match.path}['{self.index}']",
                         root=match.root,
                     )

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -1,0 +1,47 @@
+"""JSONPointer test cases."""
+import dataclasses
+
+import pytest
+
+from jsonpath import JSONPointer
+
+
+@dataclasses.dataclass
+class Case:
+    pointer: str
+    want: object
+
+
+RFC6901_DOCUMENT = {
+    "foo": ["bar", "baz"],
+    "": 0,
+    "a/b": 1,
+    "c%d": 2,
+    "e^f": 3,
+    "g|h": 4,
+    "i\\j": 5,
+    'k"l': 6,
+    " ": 7,
+    "m~n": 8,
+}
+
+RFC6901_TEST_CASES = [
+    Case(pointer="", want=RFC6901_DOCUMENT),
+    Case(pointer="/foo", want=["bar", "baz"]),
+    Case(pointer="/foo/0", want="bar"),
+    Case(pointer="/", want=0),
+    Case(pointer="/a~1b", want=1),
+    Case(pointer="/c%d", want=2),
+    Case(pointer="/e^f", want=3),
+    Case(pointer="/g|h", want=4),
+    Case(pointer=r"/i\\j", want=5),
+    Case(pointer='/k"l', want=6),
+    Case(pointer="/ ", want=7),
+    Case(pointer="/m~0n", want=8),
+]
+
+
+@pytest.mark.parametrize("case", RFC6901_TEST_CASES)
+def test_rfc6901_examples(case: Case) -> None:
+    pointer = JSONPointer(case.pointer)
+    assert pointer.resolve(RFC6901_DOCUMENT) == case.want

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -100,3 +100,11 @@ def test_resolve_with_missing_parent() -> None:
     parent, rv = pointer.resolve_with_parent(data)
     assert parent is None
     assert rv == data
+
+
+def test_resolve_with_missing_target() -> None:
+    data = {"some": {"thing": [1, 2, 3]}}
+    pointer = JSONPointer("some/other")
+    parent, rv = pointer.resolve_with_parent(data)
+    assert parent == data
+    assert rv is None

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -3,6 +3,7 @@ import pytest
 
 import jsonpath
 from jsonpath import JSONPointer
+from jsonpath import JSONPointerIndexError
 
 
 def test_match_to_pointer() -> None:
@@ -76,3 +77,26 @@ def test_sequence_type_error() -> None:
     pointer = JSONPointer("/some/thing")
     with pytest.raises(TypeError):
         pointer.resolve(data)
+
+
+def test_hyphen_index() -> None:
+    data = {"some": {"thing": [1, 2, 3]}}
+    pointer = JSONPointer("/some/thing/-")
+    with pytest.raises(JSONPointerIndexError):
+        pointer.resolve(data)
+
+
+def test_resolve_with_parent() -> None:
+    data = {"some": {"thing": [1, 2, 3]}}
+    pointer = JSONPointer("/some/thing")
+    parent, rv = pointer.resolve_with_parent(data)
+    assert parent == data["some"]
+    assert rv == data["some"]["thing"]
+
+
+def test_resolve_with_missing_parent() -> None:
+    data = {"some": {"thing": [1, 2, 3]}}
+    pointer = JSONPointer("")
+    parent, rv = pointer.resolve_with_parent(data)
+    assert parent is None
+    assert rv == data

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -6,6 +6,7 @@ import pytest
 import jsonpath
 from jsonpath import JSONPointer
 from jsonpath import JSONPointerIndexError
+from jsonpath import JSONPointerResolutionError
 
 
 def test_match_to_pointer() -> None:
@@ -125,3 +126,16 @@ def test_resolve_from_file_like() -> None:
     assert pointer.resolve(data) == [1, 2, 3]
     data.seek(0)
     assert pointer.resolve_parent(data) == ({"thing": [1, 2, 3]}, [1, 2, 3])
+
+
+def test_convenience_resolve() -> None:
+    data = {"some": {"thing": [1, 2, 3]}}
+    assert jsonpath.resolve("/some/thing/0", data) == 1
+
+    with pytest.raises(JSONPointerResolutionError):
+        jsonpath.resolve("/some/thing/99", data)
+
+
+def test_convenience_resolve_default() -> None:
+    data = {"some": {"thing": [1, 2, 3]}}
+    assert jsonpath.resolve("/some/thing/99", data, default=0) == 0

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -1,68 +1,12 @@
 """JSONPointer test cases."""
-import dataclasses
-
-import pytest
-
-from jsonpath import JSONPointer
+import jsonpath
 
 
-@dataclasses.dataclass
-class Case:
-    pointer: str
-    want: object
-
-
-RFC6901_DOCUMENT = {
-    "foo": ["bar", "baz"],
-    "": 0,
-    "a/b": 1,
-    "c%d": 2,
-    "e^f": 3,
-    "g|h": 4,
-    "i\\j": 5,
-    'k"l': 6,
-    " ": 7,
-    "m~n": 8,
-}
-
-RFC6901_TEST_CASES = [
-    Case(pointer="", want=RFC6901_DOCUMENT),
-    Case(pointer="/foo", want=["bar", "baz"]),
-    Case(pointer="/foo/0", want="bar"),
-    Case(pointer="/", want=0),
-    Case(pointer="/a~1b", want=1),
-    Case(pointer="/c%d", want=2),
-    Case(pointer="/e^f", want=3),
-    Case(pointer="/g|h", want=4),
-    Case(pointer=r"/i\\j", want=5),
-    Case(pointer='/k"l', want=6),
-    Case(pointer="/ ", want=7),
-    Case(pointer="/m~0n", want=8),
-]
-
-RFC6901_URI_TEST_CASES = [
-    Case("", want=RFC6901_DOCUMENT),
-    Case("/foo", want=["bar", "baz"]),
-    Case("/foo/0", want="bar"),
-    Case("/", want=0),
-    Case("/a~1b", want=1),
-    Case("/c%25d", want=2),
-    Case("/e%5Ef", want=3),
-    Case("/g%7Ch", want=4),
-    Case("/i%5Cj", want=5),
-    Case("/k%22l", want=6),
-    Case("/%20", want=7),
-    Case("/m~0n", want=8),
-]
-
-
-@pytest.mark.parametrize("case", RFC6901_TEST_CASES)
-def test_rfc6901_examples(case: Case) -> None:
-    pointer = JSONPointer(case.pointer)
-    assert pointer.resolve(RFC6901_DOCUMENT) == case.want
-
-
-@pytest.mark.parametrize("case", RFC6901_URI_TEST_CASES)
-def test_rfc6901_uri_examples(case: Case) -> None:
-    pointer = JSONPointer(case.pointer, unicode_escape=False, uri_decode=True)
-    assert pointer.resolve(RFC6901_DOCUMENT) == case.want
+def test_match_to_pointer() -> None:
+    data = {"some": {"thing": "else"}}
+    matches = list(jsonpath.finditer("$.some.thing", data))
+    assert len(matches) == 1
+    match = matches[0]
+    pointer = match.pointer()
+    assert pointer.resolve(data) == match.obj
+    assert pointer.resolve({"some": {"thing": "foo"}}) == "foo"

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -40,8 +40,29 @@ RFC6901_TEST_CASES = [
     Case(pointer="/m~0n", want=8),
 ]
 
+RFC6901_URI_TEST_CASES = [
+    Case("", want=RFC6901_DOCUMENT),
+    Case("/foo", want=["bar", "baz"]),
+    Case("/foo/0", want="bar"),
+    Case("/", want=0),
+    Case("/a~1b", want=1),
+    Case("/c%25d", want=2),
+    Case("/e%5Ef", want=3),
+    Case("/g%7Ch", want=4),
+    Case("/i%5Cj", want=5),
+    Case("/k%22l", want=6),
+    Case("/%20", want=7),
+    Case("/m~0n", want=8),
+]
+
 
 @pytest.mark.parametrize("case", RFC6901_TEST_CASES)
 def test_rfc6901_examples(case: Case) -> None:
     pointer = JSONPointer(case.pointer)
+    assert pointer.resolve(RFC6901_DOCUMENT) == case.want
+
+
+@pytest.mark.parametrize("case", RFC6901_URI_TEST_CASES)
+def test_rfc6901_uri_examples(case: Case) -> None:
+    pointer = JSONPointer(case.pointer, unicode_escape=False, uri_decode=True)
     assert pointer.resolve(RFC6901_DOCUMENT) == case.want

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -1,5 +1,7 @@
 """JSONPointer test cases."""
 from io import StringIO
+from typing import List
+from typing import Union
 
 import pytest
 
@@ -139,3 +141,28 @@ def test_convenience_resolve() -> None:
 def test_convenience_resolve_default() -> None:
     data = {"some": {"thing": [1, 2, 3]}}
     assert jsonpath.resolve("/some/thing/99", data, default=0) == 0
+
+
+def test_convenience_resolve_from_parts() -> None:
+    data = {"some": {"thing": [1, 2, 3]}}
+    assert jsonpath.resolve(["some", "thing", "0"], data) == 1
+
+    with pytest.raises(JSONPointerResolutionError):
+        jsonpath.resolve(["some", "thing", "99"], data)
+
+
+def test_convenience_resolve_default_from_parts() -> None:
+    data = {"some": {"thing": [1, 2, 3]}}
+    assert jsonpath.resolve(["some", "thing", "99"], data, default=0) == 0
+
+
+def test_pointer_from_parts() -> None:
+    parts: List[Union[str, int]] = ["some", "thing", 0]
+    pointer = JSONPointer.from_parts(parts)
+    assert str(pointer) == "/some/thing/0"
+
+
+def test_pointer_from_uri_encoded_parts() -> None:
+    parts: List[Union[str, int]] = ["some%20thing", "else", 0]
+    pointer = JSONPointer.from_parts(parts, uri_decode=True)
+    assert str(pointer) == "/some thing/else/0"

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -1,5 +1,8 @@
 """JSONPointer test cases."""
+import pytest
+
 import jsonpath
+from jsonpath import JSONPointer
 
 
 def test_match_to_pointer() -> None:
@@ -10,3 +13,66 @@ def test_match_to_pointer() -> None:
     pointer = match.pointer()
     assert pointer.resolve(data) == match.obj
     assert pointer.resolve({"some": {"thing": "foo"}}) == "foo"
+
+
+def test_pointer_repr() -> None:
+    data = {"some": {"thing": "else"}}
+    matches = list(jsonpath.finditer("$.some.thing", data))
+    assert len(matches) == 1
+    match = matches[0]
+    pointer = match.pointer()
+    assert str(pointer) == "/some/thing"
+
+
+def test_pointer_index_out_fo_range() -> None:
+    max_plus_one = JSONPointer.max_int_index + 1
+    min_minus_one = JSONPointer.min_int_index - 1
+
+    with pytest.raises(jsonpath.JSONPointerError):
+        JSONPointer(f"/some/thing/{max_plus_one}")
+
+    with pytest.raises(jsonpath.JSONPointerError):
+        JSONPointer(f"/some/thing/{min_minus_one}")
+
+
+def test_resolve_int_key() -> None:
+    data = {"some": {"1": "thing"}}
+    pointer = JSONPointer("/some/1")
+    assert pointer.resolve(data) == "thing"
+
+
+def test_resolve_int_missing_key() -> None:
+    data = {"some": {"1": "thing"}}
+    pointer = JSONPointer("/some/2")
+    with pytest.raises(KeyError):
+        pointer.resolve(data)
+
+
+def test_resolve_str_index() -> None:
+    data = {"some": ["a", "b", "c"]}
+    pointer = JSONPointer("/some/1", parts=("some", "1"))
+    assert pointer.resolve(data) == "b"
+
+
+def test_keys_selector() -> None:
+    data = {"some": {"thing": "else"}}
+    matches = list(jsonpath.finditer("$.some.~", data))
+    assert len(matches) == 1
+    match = matches[0]
+    pointer = match.pointer()
+    assert str(pointer) == "/some/~0thing"
+    assert pointer.resolve(data) == "thing"
+
+
+def test_mapping_key_error() -> None:
+    data = {"some": {"thing": "else"}}
+    pointer = JSONPointer("/some/other")
+    with pytest.raises(KeyError):
+        pointer.resolve(data)
+
+
+def test_sequence_type_error() -> None:
+    data = {"some": ["a", "b", "c"]}
+    pointer = JSONPointer("/some/thing")
+    with pytest.raises(TypeError):
+        pointer.resolve(data)

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -30,6 +30,12 @@ def test_pointer_repr() -> None:
     assert str(pointer) == "/some/thing"
 
 
+def test_resolve_with_default() -> None:
+    data = {"some": {"thing": "else"}}
+    pointer = JSONPointer("/some/other")
+    assert pointer.resolve(data, default=None) is None
+
+
 def test_pointer_index_out_fo_range() -> None:
     max_plus_one = JSONPointer.max_int_index + 1
     min_minus_one = JSONPointer.min_int_index - 1

--- a/tests/test_json_pointer_rfc6901.py
+++ b/tests/test_json_pointer_rfc6901.py
@@ -1,0 +1,99 @@
+"""Test cases from rfc6901 examples.
+
+The test cases defined here are taken from rfc6901. The appropriate Simplified
+BSD License is included below.
+
+Copyright (c) 2013 IETF Trust and the persons identified as authors of the
+code. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name of Internet Society, IETF or IETF Trust, nor the names of
+  specific contributors, may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+"""
+import dataclasses
+
+import pytest
+
+from jsonpath import JSONPointer
+
+
+@dataclasses.dataclass
+class Case:
+    pointer: str
+    want: object
+
+
+RFC6901_DOCUMENT = {
+    "foo": ["bar", "baz"],
+    "": 0,
+    "a/b": 1,
+    "c%d": 2,
+    "e^f": 3,
+    "g|h": 4,
+    "i\\j": 5,
+    'k"l': 6,
+    " ": 7,
+    "m~n": 8,
+}
+
+RFC6901_TEST_CASES = [
+    Case(pointer="", want=RFC6901_DOCUMENT),
+    Case(pointer="/foo", want=["bar", "baz"]),
+    Case(pointer="/foo/0", want="bar"),
+    Case(pointer="/", want=0),
+    Case(pointer="/a~1b", want=1),
+    Case(pointer="/c%d", want=2),
+    Case(pointer="/e^f", want=3),
+    Case(pointer="/g|h", want=4),
+    Case(pointer=r"/i\\j", want=5),
+    Case(pointer='/k"l', want=6),
+    Case(pointer="/ ", want=7),
+    Case(pointer="/m~0n", want=8),
+]
+
+RFC6901_URI_TEST_CASES = [
+    Case("", want=RFC6901_DOCUMENT),
+    Case("/foo", want=["bar", "baz"]),
+    Case("/foo/0", want="bar"),
+    Case("/", want=0),
+    Case("/a~1b", want=1),
+    Case("/c%25d", want=2),
+    Case("/e%5Ef", want=3),
+    Case("/g%7Ch", want=4),
+    Case("/i%5Cj", want=5),
+    Case("/k%22l", want=6),
+    Case("/%20", want=7),
+    Case("/m~0n", want=8),
+]
+
+
+@pytest.mark.parametrize("case", RFC6901_TEST_CASES)
+def test_rfc6901_examples(case: Case) -> None:
+    pointer = JSONPointer(case.pointer)
+    assert pointer.resolve(RFC6901_DOCUMENT) == case.want
+
+
+@pytest.mark.parametrize("case", RFC6901_URI_TEST_CASES)
+def test_rfc6901_uri_examples(case: Case) -> None:
+    pointer = JSONPointer(case.pointer, unicode_escape=False, uri_decode=True)
+    assert pointer.resolve(RFC6901_DOCUMENT) == case.want


### PR DESCRIPTION
This pull request defines a `JSONPointer` class, implementing [rfc6901](https://datatracker.ietf.org/doc/html/rfc6901), with methods for building a `JSONPointer` from a `JSONPathMatch`.

This forms part of our [JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902)-like Python API for modifying JSON documents (or equivalent Python objects), while keeping JSONPath read-only.

Closes #9.