### PR TITLE
feat: jsonpath.match()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Added the `JSONPointer` class and methods for converting a `JSONPathMatch` to a `JSONPointer`.
 - Added `jsonpath.resolve()`, a convenience function for resolving a [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901).
+- Added `jsonpath.match()`, which returns a `JSONPathMatch` instance for the first match of a path, or `None` if there were no matches.
 - All selectors now use `env.match_class` to instantiate new `JSONPathMatch` objects. This allows for subclassing of `JSONPathMatch`.
 
 ## Version 0.7.1

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -133,6 +133,40 @@ some_users = path.findall(some_data)
 other_users = path.findall(other_data)
 ```
 
+## `match(path, data)`
+
+Get a [`jsonpath.JSONPathMatch`](api.md#jsonpath.JSONPathMatch) instance for the first match found in _data_. If there are no matches, `None` is returned.
+
+```python
+import jsonpath
+
+data = {
+    "users": [
+        {
+            "name": "Sue",
+            "score": 100,
+        },
+        {
+            "name": "John",
+            "score": 86,
+        },
+        {
+            "name": "Sally",
+            "score": 84,
+        },
+        {
+            "name": "Jane",
+            "score": 55,
+        },
+    ]
+}
+
+match = jsonpath.match("$.users[?@.score > 85].name", data)
+if match is not None:
+    print(match)  # 'Sue' @ $['users'][0]['name']
+    print(match.obj)  # Sue
+```
+
 ## `resolve(pointer, data)`
 
 Resolve a [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901). A JSON Pointer references a single object on a specific "path" in a JSON document. Here, _pointer_ can be a string representation of a JSON Pointer, or a list of parts that make up a pointer. _data_ can be a file-like object or string containing JSON formatted data, or equivalent Python objects.

--- a/jsonpath/__init__.py
+++ b/jsonpath/__init__.py
@@ -44,6 +44,7 @@ __all__ = (
     "JSONPointerResolutionError",
     "JSONPointerTypeError",
     "Lexer",
+    "match",
     "Parser",
     "resolve",
     "UNDEFINED",
@@ -52,8 +53,9 @@ __all__ = (
 
 # For convenience
 DEFAULT_ENV = JSONPathEnvironment()
-findall = DEFAULT_ENV.findall
-finditer = DEFAULT_ENV.finditer
-findall_async = DEFAULT_ENV.findall_async
-finditer_async = DEFAULT_ENV.finditer_async
 compile = DEFAULT_ENV.compile  # noqa: A001
+findall = DEFAULT_ENV.findall
+findall_async = DEFAULT_ENV.findall_async
+finditer = DEFAULT_ENV.finditer
+finditer_async = DEFAULT_ENV.finditer_async
+match = DEFAULT_ENV.match

--- a/jsonpath/env.py
+++ b/jsonpath/env.py
@@ -198,6 +198,8 @@ class JSONPathEnvironment:
 
         Raises:
             JSONPathSyntaxError: If the path is invalid.
+            JSONPathTypeError: If a filter expression attempts to use types in
+                an incompatible way.
         """
         return self.compile(path).findall(data, filter_context=filter_context)
 
@@ -223,9 +225,41 @@ class JSONPathEnvironment:
         Returns:
             An iterator yielding `JSONPathMatch` objects for each match.
 
-        Raises a `JSONPathSyntaxError` if the path is invalid.
+        Raises:
+            JSONPathSyntaxError: If the path is invalid.
+            JSONPathTypeError: If a filter expression attempts to use types in
+                an incompatible way.
         """
         return self.compile(path).finditer(data, filter_context=filter_context)
+
+    def match(
+        self,
+        path: str,
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
+        *,
+        filter_context: Optional[FilterContextVars] = None,
+    ) -> Union[JSONPathMatch, None]:
+        """Return a `JSONPathMatch` instance for the first object found in _data_.
+
+        `None` is returned if there are no matches.
+
+        Arguments:
+            path: The JSONPath as a string.
+            data: A JSON document or Python object implementing the `Sequence`
+                or `Mapping` interfaces.
+            filter_context: Arbitrary data made available to filters using
+                the _filter context_ selector.
+
+        Returns:
+            A `JSONPathMatch` object for the first match, or `None` if there were
+                no matches.
+
+        Raises:
+            JSONPathSyntaxError: If the path is invalid.
+            JSONPathTypeError: If a filter expression attempts to use types in
+                an incompatible way.
+        """
+        return self.compile(path).match(data, filter_context=filter_context)
 
     async def findall_async(
         self,

--- a/jsonpath/path.py
+++ b/jsonpath/path.py
@@ -184,6 +184,36 @@ class JSONPath:
 
         return matches
 
+    def match(
+        self,
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
+        *,
+        filter_context: Optional[FilterContextVars] = None,
+    ) -> Union[JSONPathMatch, None]:
+        """Return a `JSONPathMatch` instance for the first object found in _data_.
+
+        `None` is returned if there are no matches.
+
+        Arguments:
+            data: A JSON document or Python object implementing the `Sequence`
+                or `Mapping` interfaces.
+            filter_context: Arbitrary data made available to filters using
+                the _filter context_ selector.
+
+        Returns:
+            A `JSONPathMatch` object for the first match, or `None` if there were
+                no matches.
+
+        Raises:
+            JSONPathSyntaxError: If the path is invalid.
+            JSONPathTypeError: If a filter expression attempts to use types in
+                an incompatible way.
+        """
+        try:
+            return next(iter(self.finditer(data, filter_context=filter_context)))
+        except StopIteration:
+            return None
+
     def empty(self) -> bool:
         """Return `True` if this path has no selectors."""
         return not bool(self._selectors)
@@ -284,6 +314,36 @@ class CompoundJSONPath:
                 matches = (match for match in matches if match.obj in _objs)
 
         return matches
+
+    def match(
+        self,
+        data: Union[str, IOBase, Sequence[Any], Mapping[str, Any]],
+        *,
+        filter_context: Optional[FilterContextVars] = None,
+    ) -> Union[JSONPathMatch, None]:
+        """Return a `JSONPathMatch` instance for the first object found in _data_.
+
+        `None` is returned if there are no matches.
+
+        Arguments:
+            data: A JSON document or Python object implementing the `Sequence`
+                or `Mapping` interfaces.
+            filter_context: Arbitrary data made available to filters using
+                the _filter context_ selector.
+
+        Returns:
+            A `JSONPathMatch` object for the first match, or `None` if there were
+                no matches.
+
+        Raises:
+            JSONPathSyntaxError: If the path is invalid.
+            JSONPathTypeError: If a filter expression attempts to use types in
+                an incompatible way.
+        """
+        try:
+            return next(iter(self.finditer(data, filter_context=filter_context)))
+        except StopIteration:
+            return None
 
     async def findall_async(
         self,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -119,3 +119,29 @@ def test_find_iter_async_with_extra_filter_context(env: JSONPathEnvironment) -> 
         return [match.obj async for match in matches]
 
     assert asyncio.run(coro()) == [{"some": 1, "thing": 2}]
+
+
+def test_match(env: JSONPathEnvironment) -> None:
+    """Test that we can get the first match of a path."""
+    match = env.match("$.some", {"some": 1, "thing": 2})
+    assert match is not None
+    assert match.obj == 1
+
+
+def test_no_match(env: JSONPathEnvironment) -> None:
+    """Test that we get `None` if there are no matches."""
+    match = env.match("$.other", {"some": 1, "thing": 2})
+    assert match is None
+
+
+def test_match_compound_path(env: JSONPathEnvironment) -> None:
+    """Test that we can get the first match of a compound path."""
+    match = env.match("$.some | $.thing", {"some": 1, "thing": 2})
+    assert match is not None
+    assert match.obj == 1
+
+
+def test_no_match_compound_path(env: JSONPathEnvironment) -> None:
+    """Test that we get `None` if there are no matches in a compound path."""
+    match = env.match("$.other | $.foo", {"some": 1, "thing": 2})
+    assert match is None


### PR DESCRIPTION
This pull requests adds a `match()` method to `JSONPathEnvironment` and `JSONPath`. `match()` returns a `JSONPathMatch` instance for the first match in a path, or `None` if there are no matches.

```python
import jsonpath

data = {
    "users": [
        {
            "name": "Sue",
            "score": 100,
        },
        {
            "name": "John",
            "score": 86,
        },
        {
            "name": "Sally",
            "score": 84,
        },
        {
            "name": "Jane",
            "score": 55,
        },
    ]
}

match = jsonpath.match("$.users[?@.score > 85].name", data)
if match is not None:
    print(match)
    print(match.obj)
```

`match()` is roughly equivalent to this:

```python
try:
    match = next(iter(jsonpath.finditer(path, data)))
except StopIteration:
    match = None
```