### PR TITLE
fix: root pointer from parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Python JSONPath Change Log
 
+## Version 0.8.1
+
+**Fixes**
+
+- Fixed the string representation of a `JSONPointer` when built using `JSONPointer.from_parts()` and pointing to the document root. See [#21](https://github.com/jg-rp/python-jsonpath/issues/21).
+
 ## Version 0.8.0
 
 **Breaking changes**

--- a/jsonpath/__about__.py
+++ b/jsonpath/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present James Prior <jamesgr.prior@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -232,11 +232,16 @@ class JSONPointer:
     ) -> JSONPointer:
         """Return a JSON Pointer for the path from a JSONPathMatch instance."""
         # A rfc6901 string representation of match.parts.
-        return cls(
-            "/"
-            + "/".join(
+        if not match.parts:
+            # This should not happen, unless the JSONPathMatch has been tampered with.
+            pointer = ""
+        else:
+            pointer = "/" + "/".join(
                 str(p).replace("~", "~0").replace("/", "~1") for p in match.parts
-            ),
+            )
+
+        return cls(
+            pointer,
             parts=match.parts,
             unicode_escape=False,
             uri_decode=False,
@@ -269,9 +274,18 @@ class JSONPointer:
                 .decode("utf-16")
                 for p in _parts
             )
+
         __parts = tuple(_parts)
+
+        if __parts:
+            pointer = "/" + "/".join(
+                p.replace("~", "~0").replace("/", "~1") for p in __parts
+            )
+        else:
+            pointer = ""
+
         return cls(
-            "/" + "/".join(p.replace("~", "~0").replace("/", "~1") for p in __parts),
+            pointer,
             parts=__parts,
             unicode_escape=False,
             uri_decode=False,

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -170,6 +170,18 @@ def test_pointer_from_parts() -> None:
     assert str(pointer) == "/some/thing/0"
 
 
+def test_pointer_from_empty_parts() -> None:
+    parts: List[Union[str, int]] = []
+    pointer = JSONPointer.from_parts(parts)
+    assert str(pointer) == ""
+
+
+def test_pointer_from_only_empty_string_parts() -> None:
+    parts: List[Union[str, int]] = [""]
+    pointer = JSONPointer.from_parts(parts)
+    assert str(pointer) == "/"
+
+
 def test_pointer_from_uri_encoded_parts() -> None:
     parts: List[Union[str, int]] = ["some%20thing", "else", 0]
     pointer = JSONPointer.from_parts(parts, uri_decode=True)


### PR DESCRIPTION
This pull request fixes #21 by checking for empty parts before building an RFC6901 string representation of them.