### PR TITLE
feat: command line interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Python JSONPath Change Log
 
+## Version 0.9.0 (unreleased)
+
+**Features**
+
+- Added a command line interface, exposing JSONPath, JSON Pointer and JSON Patch features.
+
 ## Version 0.8.1
 
 **Fixes**

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,8 @@
 # Command Line Interface
 
-Python JSONPath includes a script called `json`, exposing [JSONPath](https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base-13), [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) and [JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902) features on the command line. Use the `--version` argument to check the current version of Python JSONPath, and the `--help` argument to display command information.
+**_New in version 0.9.0_**
+
+Python JSONPath includes a script called `json`, exposing [JSONPath](quickstart.md#findallpath-data), [JSON Pointer](quickstart.md#pointerresolvepointer-data) and [JSON Patch](quickstart.md#patchapplypatch-data) features on the command line. Use the `--version` argument to check the current version of Python JSONPath, and the `--help` argument to display command information.
 
 
 ```console
@@ -64,7 +66,7 @@ optional arguments:
 
 ## Global Options
 
-These arguments apply to any subcommand, and must be listed before the command.
+These arguments apply to any subcommand and must be listed before the command.
 
 ### `--debug`
 
@@ -97,7 +99,7 @@ jsonpath.exceptions.JSONPathSyntaxError: unexpected token '1', line 1, column 2
 
 ### `--pretty`
 
-Enable pretty formatting when outputting JSON. Add's newlines and indentation to output specified with the `-o` or `--output` option. Without the `--pretty` option, the following example output is on one line.
+Enable pretty formatting when outputting JSON. Adds newlines and indentation to output specified with the `-o` or `--output` option. Without the `--pretty` option, the following example output is on one line.
 
 ```console
 $ json pointer -p "/categories/1/products/0" -f /tmp/source.json 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,188 @@
+# Command Line Interface
+
+Python JSONPath includes a script called `json`, exposing [JSONPath](https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base-13), [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) and [JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902) features on the command line. Use the `--version` argument to check the current version of Python JSONPath, and the `--help` argument to display command information.
+
+
+```console
+$ json --version
+python-jsonpath, version 0.9.0
+```
+
+```console
+$ json --help
+usage: json [-h] [--debug] [--pretty] [-v] [--no-unicode-escape] COMMAND ...
+
+JSONPath, JSON Pointer and JSON Patch utilities.
+
+positional arguments:
+  COMMAND
+    path               Find objects in a JSON document given a JSONPath.
+    pointer            Resolve a JSON Pointer against a JSON document.
+    patch              Apply a JSON Patch to a JSON document.
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --debug              Show stack traces. (default: False)
+  --pretty             Add indents and newlines to output JSON. (default: False)
+  -v, --version        Show the version and exit.
+  --no-unicode-escape  Disable decoding of UTF-16 escape sequence within paths and pointers. (default:
+                       False)
+
+Use [json COMMAND --help] for command specific help.
+
+Usage Examples:
+  Find objects in source.json matching a JSONPath, write them to result.json.
+  $ json path -q "$.foo['bar'][?@.baz > 1]" -f source.json -o result.json
+
+  Resolve a JSON Pointer against source.json, pretty print the result to stdout.
+  $ json --pretty pointer -p "/foo/bar/0" -f source.json
+
+  Apply JSON Patch patch.json to JSON from stdin, output to result.json.
+  $ cat source.json | json patch /path/to/patch.json -o result.json
+```
+
+Use `json COMMAND --help` for command specific help.
+
+```console
+$ json path --help
+usage: json path [-h] (-q QUERY | -r PATH_FILE) [-f FILE] [-o OUTPUT]
+
+Find objects in a JSON document given a JSONPath.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -q QUERY, --query QUERY
+                        JSONPath query string.
+  -r PATH_FILE, --path-file PATH_FILE
+                        Text file containing a JSONPath query.
+  -f FILE, --file FILE  File to read the target JSON document from. Defaults to reading from the
+                        standard input stream.
+  -o OUTPUT, --output OUTPUT
+                        File to write resulting objects to, as a JSON array. Defaults to the standard
+                        output stream.
+```
+
+## Global Options
+
+These arguments apply to any subcommand, and must be listed before the command.
+
+### `--debug`
+
+Enable debugging. Display full stack traces, if available, when errors occur. Without the `--debug` option, the following example shows a short "json path syntax error" message.
+
+```console
+$ json path -q "$.1" -f /tmp/source.json 
+json path syntax error: unexpected token '1', line 1, column 2
+```
+
+With the `--debug` option, we get the stack trace triggered by `JSONPathSyntaxError`.
+
+```console
+$ json --debug path -q "$.1" -f /tmp/source.json 
+Traceback (most recent call last):
+  File "/home/james/.local/share/virtualenvs/jsonpath_cli-8Tb3e-ir/bin/json", line 8, in <module>
+    sys.exit(main())
+  File "/home/james/.local/share/virtualenvs/jsonpath_cli-8Tb3e-ir/lib/python3.9/site-packages/jsonpath/cli.py", line 338, in main
+    args.func(args)
+  File "/home/james/.local/share/virtualenvs/jsonpath_cli-8Tb3e-ir/lib/python3.9/site-packages/jsonpath/cli.py", line 234, in handle_path_command
+    path = jsonpath.compile(args.query or args.path_file.read())
+  File "/home/james/.local/share/virtualenvs/jsonpath_cli-8Tb3e-ir/lib/python3.9/site-packages/jsonpath/env.py", line 148, in compile
+    _path: Union[JSONPath, CompoundJSONPath] = JSONPath(
+  File "/home/james/.local/share/virtualenvs/jsonpath_cli-8Tb3e-ir/lib/python3.9/site-packages/jsonpath/path.py", line 49, in __init__
+    self.selectors = tuple(selectors)
+  File "/home/james/.local/share/virtualenvs/jsonpath_cli-8Tb3e-ir/lib/python3.9/site-packages/jsonpath/parse.py", line 256, in parse
+    raise JSONPathSyntaxError(
+jsonpath.exceptions.JSONPathSyntaxError: unexpected token '1', line 1, column 2
+```
+
+### `--pretty`
+
+Enable pretty formatting when outputting JSON. Add's newlines and indentation to output specified with the `-o` or `--output` option. Without the `--pretty` option, the following example output is on one line.
+
+```console
+$ json pointer -p "/categories/1/products/0" -f /tmp/source.json 
+{"title": "Cap", "description": "Baseball cap", "price": 15.0}
+```
+
+With the `--pretty` option, we get nicely formatted JSON output.
+
+```console
+$ json --pretty pointer -p "/categories/1/products/0" -f /tmp/source.json 
+{
+  "title": "Cap",
+  "description": "Baseball cap",
+  "price": 15.0
+}
+```
+
+### `--no-unicode-escape`
+
+Disable decoding of UTF-16 escape sequences, including surrogate paris. This can improve performance if you know your paths and pointers don't contain UTF-16 escape sequences.
+
+```console
+$ json --no-unicode-escape path -q "$.price_cap" -f /tmp/source.json 
+```
+
+## Commands
+
+One of the subcommands `path`, `pointer` or `patch` must be specified, depending on whether you want to search a JSON document with a JSONPath, resolve a JSON Pointer against a JSON document or apply a JSON Patch to a JSON Document.
+
+### `path`
+
+Find objects in a JSON document given a JSONPath. One of `-q`/`--query` or `-r`/`--path-file` must be given. `-q` being a JSONPath given on the command line as a string, `-r` being the path to a file containing a JSONPath.
+
+#### `-q` / `--query`
+
+The JSONPath as a string.
+
+```console
+$ json path -q "$.price_cap" -f /tmp/source.json
+```
+
+```console
+$ json path --query "$.price_cap" -f /tmp/source.json
+```
+
+#### `-r` / `--path-file`
+
+The path to a file containing a JSONPath.
+
+```console
+$ json path -r /tmp/path.txt -f /tmp/source.json
+```
+
+```console
+$ json path --path-file /tmp/path.txt -f /tmp/source.json
+```
+
+#### `-f` / `--file`
+
+The path to a file containing the target JSON document. If omitted or a hyphen (`-`), the target JSON document will be read from the standard input stream.
+
+```console
+$ json path -q "$.price_cap" -f /tmp/source.json
+```
+
+```console
+$ json path -q "$.price_cap" --file /tmp/source.json
+```
+
+#### `-o` / `--output`
+
+The path to a file to write resulting objects to, as a JSON array. If omitted or a hyphen (`-`) is given, results will be written to the standard output stream.
+
+```console
+$ json path -q "$.price_cap" -f /tmp/source.json -o /result.json
+```
+
+```console
+$ json path -q "$.price_cap" -f /tmp/source.json --output /result.json
+```
+
+### `pointer`
+
+TODO:
+
+### `patch`
+
+TODO:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,6 +131,10 @@ One of the subcommands `path`, `pointer` or `patch` must be specified, depending
 
 Find objects in a JSON document given a JSONPath. One of `-q`/`--query` or `-r`/`--path-file` must be given. `-q` being a JSONPath given on the command line as a string, `-r` being the path to a file containing a JSONPath.
 
+```
+json path [-h] (-q QUERY | -r PATH_FILE) [-f FILE] [-o OUTPUT]
+```
+
 #### `-q` / `--query`
 
 The JSONPath as a string.
@@ -172,17 +176,129 @@ $ json path -q "$.price_cap" --file /tmp/source.json
 The path to a file to write resulting objects to, as a JSON array. If omitted or a hyphen (`-`) is given, results will be written to the standard output stream.
 
 ```console
-$ json path -q "$.price_cap" -f /tmp/source.json -o /result.json
+$ json path -q "$.price_cap" -f /tmp/source.json -o result.json
 ```
 
 ```console
-$ json path -q "$.price_cap" -f /tmp/source.json --output /result.json
+$ json path -q "$.price_cap" -f /tmp/source.json --output result.json
 ```
 
 ### `pointer`
 
-TODO:
+Resolve a JSON Pointer against a JSON document. One of `-p`/`--pointer` or `-r`/`--pointer-file` must be given. `-p` being a JSON Pointer given on the command line as a string, `-r` being the path to a file containing a JSON Pointer.
+
+```
+json pointer [-h] (-p POINTER | -r POINTER_FILE) [-f FILE] [-o OUTPUT] [-u]
+```
+
+#### `-p` / `--pointer`
+
+An RFC 6901 formatted JSON Pointer string.
+
+```console
+$ json pointer -p "/categories/0/name" -f /tmp/source.json
+```
+
+```console
+$ json pointer --pointer "/categories/0/name" -f /tmp/source.json
+```
+
+#### `-r` / `--pointer-file`
+
+The path to a file containing a JSON Pointer.
+
+```console
+$ json pointer -r /tmp/pointer.txt -f /tmp/source.json
+```
+
+```console
+$ json pointer --pointer-file /tmp/pointer.txt -f /tmp/source.json
+```
+
+#### `-f` / `--file`
+
+The path to a file containing the target JSON document. If omitted or a hyphen (`-`), the target JSON document will be read from the standard input stream.
+
+```console
+$ json pointer -p "/categories/0/name" -f /tmp/source.json
+```
+
+```console
+$ json pointer -p "/categories/0/name" --file /tmp/source.json
+```
+
+#### `-o` / `--output`
+
+The path to a file to write the resulting object to. If omitted or a hyphen (`-`) is given, results will be written to the standard output stream.
+
+```console
+$ json pointer -p "/categories/0/name" -f /tmp/source.json -o result.json
+```
+```console
+$ json pointer -p "/categories/0/name" -f /tmp/source.json --output result.json
+```
+
+#### `-u` / `--uri-decode`
+
+Enable URI decoding of the JSON Pointer. In this example, we would look for a property called "hello world" in the root of the target document.
+
+```console
+$ json pointer -p "/hello%20world" -f /tmp/source.json -u
+```
+
+```console
+$ json pointer -p "/hello%20world" -f /tmp/source.json --uri-decode
+```
 
 ### `patch`
 
-TODO:
+Apply a JSON Patch to a JSON document. Unlike `path` and `pointer` commands, a patch can't be given as a string argument. `PATCH` is a positional argument that should be a file path to a JSON Patch document or a hyphen (`-`), which means the patch document will be read from the standard input stream.
+
+```
+json patch [-h] [-f FILE] [-o OUTPUT] [-u] PATCH
+```
+
+These examples read the patch from `patch.json` and the document to modify from `target.json`
+
+```console
+$ json patch /tmp/patch.json -f /tmp/target.json
+```
+
+```console
+$ cat /tmp/patch.json | json patch - -f /tmp/target.json
+```
+
+#### `-f` / `--file`
+
+The path to a file containing the target JSON document. If omitted or a hyphen (`-`), the target JSON document will be read from the standard input stream.
+
+```console
+$ json patch /tmp/patch.json -f /tmp/target.json
+```
+
+```console
+$ json patch /tmp/patch.json --file /tmp/target.json
+```
+
+#### `-o` / `--output`
+
+The path to a file to write the resulting object to. If omitted or a hyphen (`-`) is given, results will be written to the standard output stream.
+
+```console
+$ json patch /tmp/patch.json -f /tmp/target.json -o result.json
+```
+```console
+$ json patch /tmp/patch.json -f /tmp/target.json --output result.json
+```
+
+#### `-u` / `--uri-decode`
+
+Enable URI decoding of JSON Pointers in the patch document.
+
+```console
+$ json patch /tmp/patch.json -f /tmp/target.json -u
+```
+
+```console
+$ json patch /tmp/patch.json -f /tmp/target.json --uri-decode
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,12 @@ Or [Pipenv](https://pipenv.pypa.io/en/latest/):
 pipenv install python-jsonpath
 ```
 
+Or [pipx](https://pypa.github.io/pipx/)
+
+```console
+pipx install python-jsonpath
+```
+
 Or from [conda-forge](https://anaconda.org/conda-forge/python-jsonpath):
 
 ```console

--- a/jsonpath/__about__.py
+++ b/jsonpath/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present James Prior <jamesgr.prior@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.8.1"
+__version__ = "0.9.0"

--- a/jsonpath/__main__.py
+++ b/jsonpath/__main__.py
@@ -1,0 +1,4 @@
+"""CLI entry point."""
+from jsonpath.cli import main
+
+main()

--- a/jsonpath/cli.py
+++ b/jsonpath/cli.py
@@ -11,6 +11,8 @@ from jsonpath.exceptions import JSONPathSyntaxError
 from jsonpath.exceptions import JSONPathTypeError
 from jsonpath.exceptions import JSONPointerResolutionError
 
+INDENT = 2
+
 
 def path_sub_command(parser: argparse.ArgumentParser) -> None:  # noqa: D103
     parser.set_defaults(func=handle_path_command)
@@ -25,7 +27,7 @@ def path_sub_command(parser: argparse.ArgumentParser) -> None:  # noqa: D103
     group.add_argument(
         "-r",
         "--path-file",
-        type=argparse.FileType(mode="rb"),
+        type=argparse.FileType(mode="r"),
         help="Text file containing a JSONPath query.",
     )
 
@@ -65,7 +67,7 @@ def pointer_sub_command(parser: argparse.ArgumentParser) -> None:  # noqa: D103
     group.add_argument(
         "-r",
         "--pointer-file",
-        type=argparse.FileType(mode="rb"),
+        type=argparse.FileType(mode="r"),
         help="Text file containing an RFC 6901 formatted JSON Pointer string.",
     )
 
@@ -262,7 +264,7 @@ def handle_path_command(args: argparse.Namespace) -> None:  # noqa: PLR0912
         sys.stderr.write(f"json path type error: {err}\n")
         sys.exit(1)
 
-    indent = 2 if args.pretty else None
+    indent = INDENT if args.pretty else None
     json.dump(matches, args.output, indent=indent)
 
 
@@ -289,7 +291,7 @@ def handle_pointer_command(args: argparse.Namespace) -> None:
         sys.stderr.write(str(err) + "\n")
         sys.exit(1)
 
-    indent = 2 if args.pretty else None
+    indent = INDENT if args.pretty else None
     json.dump(match, args.output, indent=indent)
 
 
@@ -327,7 +329,7 @@ def handle_patch_command(args: argparse.Namespace) -> None:
         sys.stderr.write(str(err) + "\n")
         sys.exit(1)
 
-    indent = 2 if args.pretty else None
+    indent = INDENT if args.pretty else None
     json.dump(patched, args.output, indent=indent)
 
 

--- a/jsonpath/cli.py
+++ b/jsonpath/cli.py
@@ -144,7 +144,7 @@ Use [json COMMAND --help] for command specific help.
 
 Usage Examples:
   Find objects in source.json matching a JSONPath, write them to result.json.
-  $ json path -q "$.foo['bar'][?@.baz > 1]" -f source.json -o results.json
+  $ json path -q "$.foo['bar'][?@.baz > 1]" -f source.json -o result.json
 
   Resolve a JSON Pointer against source.json, pretty print the result to stdout.
   $ json --pretty pointer -p "/foo/bar/0" -f source.json
@@ -185,7 +185,7 @@ def setup_parser() -> argparse.ArgumentParser:  # noqa: D103
         "-v",
         "--version",
         action="version",
-        version=f"python-jsonpath version {__version__}",
+        version=f"python-jsonpath, version {__version__}",
         help="Show the version and exit.",
     )
 
@@ -258,6 +258,11 @@ def handle_path_command(args: argparse.Namespace) -> None:  # noqa: PLR0912
 
     try:
         matches = path.findall(target)
+    except json.JSONDecodeError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"target document json decode error: {err}\n")
+        sys.exit(1)
     except JSONPathTypeError as err:
         if args.debug:
             raise
@@ -279,6 +284,8 @@ def handle_pointer_command(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     pointer = args.pointer or args.pointer_file.read()
+    if args.pointer_file:
+        args.pointer_file.close()
 
     # TODO: default value or exist with non-zero
     try:

--- a/jsonpath/cli.py
+++ b/jsonpath/cli.py
@@ -270,9 +270,13 @@ def handle_path_command(args: argparse.Namespace) -> None:  # noqa: PLR0912
 
 def handle_pointer_command(args: argparse.Namespace) -> None:
     """Handle the `pointer` sub command."""
-    pointer = args.pointer or args.pointer_file.read()
+    # Empty string is OK.
+    if args.pointer is not None:
+        pointer = args.pointer
+    else:
+        # TODO: is a property with a trailing newline OK?
+        pointer = args.pointer_file.read().strip()
 
-    # TODO: default value or exist with non-zero
     try:
         match = jsonpath.pointer.resolve(
             pointer,

--- a/jsonpath/cli.py
+++ b/jsonpath/cli.py
@@ -1,0 +1,339 @@
+"""JSONPath, JSON Pointer and JSON Patch command line interface."""
+import argparse
+import json
+import sys
+
+import jsonpath
+from jsonpath.__about__ import __version__
+from jsonpath.exceptions import JSONPatchError
+from jsonpath.exceptions import JSONPathIndexError
+from jsonpath.exceptions import JSONPathSyntaxError
+from jsonpath.exceptions import JSONPathTypeError
+from jsonpath.exceptions import JSONPointerResolutionError
+
+
+def path_sub_command(parser: argparse.ArgumentParser) -> None:  # noqa: D103
+    parser.set_defaults(func=handle_path_command)
+    group = parser.add_mutually_exclusive_group(required=True)
+
+    group.add_argument(
+        "-q",
+        "--query",
+        help="JSONPath query string.",
+    )
+
+    group.add_argument(
+        "-r",
+        "--path-file",
+        type=argparse.FileType(mode="rb"),
+        help="Text file containing a JSONPath query.",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--file",
+        type=argparse.FileType(mode="rb"),
+        default=sys.stdin,
+        help=(
+            "File to read the target JSON document from. "
+            "Defaults to reading from the standard input stream."
+        ),
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType(mode="w"),
+        default=sys.stdout,
+        help=(
+            "File to write resulting objects to, as a JSON array. "
+            "Defaults to the standard output stream."
+        ),
+    )
+
+
+def pointer_sub_command(parser: argparse.ArgumentParser) -> None:  # noqa: D103
+    parser.set_defaults(func=handle_pointer_command)
+    group = parser.add_mutually_exclusive_group(required=True)
+
+    group.add_argument(
+        "-p",
+        "--pointer",
+        help="RFC 6901 formatted JSON Pointer string.",
+    )
+
+    group.add_argument(
+        "-r",
+        "--pointer-file",
+        type=argparse.FileType(mode="rb"),
+        help="Text file containing an RFC 6901 formatted JSON Pointer string.",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--file",
+        type=argparse.FileType(mode="rb"),
+        default=sys.stdin,
+        help=(
+            "File to read the target JSON document from. "
+            "Defaults to reading from the standard input stream."
+        ),
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType(mode="w"),
+        default=sys.stdout,
+        help=(
+            "File to write the resulting object to, in JSON format. "
+            "Defaults to the standard output stream."
+        ),
+    )
+
+    parser.add_argument(
+        "-u",
+        "--uri-decode",
+        action="store_true",
+        help="Unescape URI escape sequences found in JSON Pointers",
+    )
+
+
+def patch_sub_command(parser: argparse.ArgumentParser) -> None:  # noqa: D103
+    parser.set_defaults(func=handle_patch_command)
+
+    parser.add_argument(
+        "patch",
+        type=argparse.FileType(mode="rb"),
+        metavar="PATCH",
+        help="File containing an RFC 6902 formatted JSON Patch.",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--file",
+        type=argparse.FileType(mode="rb"),
+        default=sys.stdin,
+        help=(
+            "File to read the target JSON document from. "
+            "Defaults to reading from the standard input stream."
+        ),
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType(mode="w"),
+        default=sys.stdout,
+        help=(
+            "File to write the resulting JSON document to. "
+            "Defaults to the standard output stream."
+        ),
+    )
+
+    parser.add_argument(
+        "-u",
+        "--uri-decode",
+        action="store_true",
+        help="Unescape URI escape sequences found in JSON Pointers",
+    )
+
+
+_EPILOG = """\
+Use [json COMMAND --help] for command specific help.
+
+Usage Examples:
+  Find objects in source.json matching a JSONPath, write them to result.json.
+  $ json path -q "$.foo['bar'][?@.baz > 1]" -f source.json -o results.json
+
+  Resolve a JSON Pointer against source.json, pretty print the result to stdout.
+  $ json --pretty pointer -p "/foo/bar/0" -f source.json
+
+  Apply JSON Patch patch.json to JSON from stdin, output to result.json.
+  $ cat source.json | json patch /path/to/patch.json -o result.json
+"""
+
+
+class DescriptionHelpFormatter(
+    argparse.RawDescriptionHelpFormatter,
+    argparse.ArgumentDefaultsHelpFormatter,
+):
+    """Raw epilog formatter with defaults."""
+
+
+def setup_parser() -> argparse.ArgumentParser:  # noqa: D103
+    parser = argparse.ArgumentParser(
+        prog="json",
+        formatter_class=DescriptionHelpFormatter,
+        description="JSONPath, JSON Pointer and JSON Patch utilities.",
+        epilog=_EPILOG,
+    )
+
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Show stack traces.",
+    )
+
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Add indents and newlines to output JSON.",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"python-jsonpath version {__version__}",
+        help="Show the version and exit.",
+    )
+
+    parser.add_argument(
+        "--no-unicode-escape",
+        action="store_true",
+        help="Disable decoding of UTF-16 escape sequence within paths and pointers.",
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="command",
+        required=True,
+        metavar="COMMAND",
+    )
+
+    path_sub_command(
+        subparsers.add_parser(
+            name="path",
+            help="Find objects in a JSON document given a JSONPath.",
+            description="Find objects in a JSON document given a JSONPath.",
+        )
+    )
+
+    pointer_sub_command(
+        subparsers.add_parser(
+            name="pointer",
+            help="Resolve a JSON Pointer against a JSON document.",
+            description="Resolve a JSON Pointer against a JSON document.",
+        )
+    )
+
+    patch_sub_command(
+        subparsers.add_parser(
+            name="patch",
+            help="Apply a JSON Patch to a JSON document.",
+            description="Apply a JSON Patch to a JSON document.",
+        )
+    )
+
+    return parser
+
+
+def handle_path_command(args: argparse.Namespace) -> None:  # noqa: PLR0912
+    """Handle the `path` sub command."""
+    try:
+        target = json.load(args.file)
+    except json.JSONDecodeError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"target document json decode error: {err}\n")
+        sys.exit(1)
+
+    try:
+        path = jsonpath.compile(args.query or args.path_file.read())
+    except JSONPathSyntaxError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"json path syntax error: {err}\n")
+        sys.exit(1)
+    except JSONPathTypeError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"json path type error: {err}\n")
+        sys.exit(1)
+    except JSONPathIndexError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"json path index error: {err}\n")
+        sys.exit(1)
+
+    try:
+        matches = path.findall(target)
+    except JSONPathTypeError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"json path type error: {err}\n")
+        sys.exit(1)
+
+    indent = 2 if args.pretty else None
+    json.dump(matches, args.output, indent=indent)
+
+
+def handle_pointer_command(args: argparse.Namespace) -> None:
+    """Handle the `pointer` sub command."""
+    try:
+        target = json.load(args.file)
+    except json.JSONDecodeError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"target document json decode error: {err}\n")
+        sys.exit(1)
+
+    pointer = args.pointer or args.pointer_file.read()
+
+    # TODO: default value or exist with non-zero
+    try:
+        match = jsonpath.pointer.resolve(
+            pointer,
+            target,
+            unicode_escape=args.no_unicode_escape,
+            uri_decode=args.uri_decode,
+        )
+    except JSONPointerResolutionError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(str(err) + "\n")
+        sys.exit(1)
+
+    indent = 2 if args.pretty else None
+    json.dump(match, args.output, indent=indent)
+
+
+def handle_patch_command(args: argparse.Namespace) -> None:
+    """Handle the `patch` sub command."""
+    try:
+        target = json.load(args.file)
+    except json.JSONDecodeError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"target document json decode error: {err}\n")
+        sys.exit(1)
+
+    try:
+        patch = json.load(args.patch)
+    except json.JSONDecodeError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(f"patch document json decode error: {err}\n")
+        sys.exit(1)
+
+    try:
+        patched = jsonpath.patch.apply(patch, target)
+    except JSONPatchError as err:
+        if args.debug:
+            raise
+        sys.stderr.write(str(err) + "\n")
+        sys.exit(1)
+
+    indent = 2 if args.pretty else None
+    json.dump(patched, args.output, indent=indent)
+
+
+def main() -> None:
+    """CLI argument parser entry point."""
+    parser = setup_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/jsonpath/cli.py
+++ b/jsonpath/cli.py
@@ -232,8 +232,14 @@ def setup_parser() -> argparse.ArgumentParser:  # noqa: D103
 
 def handle_path_command(args: argparse.Namespace) -> None:  # noqa: PLR0912
     """Handle the `path` sub command."""
+    # Empty string is OK.
+    if args.query is not None:
+        path = args.query
+    else:
+        path = args.query_file.read().strip()
+
     try:
-        path = jsonpath.compile(args.query or args.path_file.read())
+        path = jsonpath.compile(path)
     except JSONPathSyntaxError as err:
         if args.debug:
             raise

--- a/jsonpath/env.py
+++ b/jsonpath/env.py
@@ -137,6 +137,11 @@ class JSONPathEnvironment:
             A `JSONPath` or `CompoundJSONPath`, ready to match against some data.
                 Expect a `CompoundJSONPath` if the path string uses the _union_ or
                 _intersection_ operators.
+
+        Raises:
+            JSONPathSyntaxError: If _path_ is invalid.
+            JSONPathTypeError: If filter functions are given arguments of an
+                unacceptable type.
         """
         tokens = self.lexer.tokenize(path)
         stream = TokenStream(tokens)

--- a/jsonpath/exceptions.py
+++ b/jsonpath/exceptions.py
@@ -91,13 +91,22 @@ class JSONPointerResolutionError(JSONPointerError):
 class JSONPointerIndexError(JSONPointerResolutionError, IndexError):
     """An exception raised when an array index is out of range."""
 
+    def __str__(self) -> str:
+        return f"pointer index error {super().__str__()}"
+
 
 class JSONPointerKeyError(JSONPointerResolutionError, KeyError):
     """An exception raised when a pointer references a mapping with a missing key."""
 
+    def __str__(self) -> str:
+        return f"pointer key error {super().__str__()}"
+
 
 class JSONPointerTypeError(JSONPointerResolutionError, TypeError):
     """An exception raised when a pointer resolves a string against a sequence."""
+
+    def __str__(self) -> str:
+        return f"pointer type error {super().__str__()}"
 
 
 class JSONPatchError(Exception):

--- a/jsonpath/patch.py
+++ b/jsonpath/patch.py
@@ -547,17 +547,11 @@ class JSONPatch:
             except JSONPatchTestFailure as err:
                 raise JSONPatchTestFailure(f"test failed ({op.name}:{i})") from err
             except JSONPointerKeyError as err:
-                raise JSONPatchError(
-                    f"pointer key error {err} ({op.name}:{i})"
-                ) from err
+                raise JSONPatchError(f"{err} ({op.name}:{i})") from err
             except JSONPointerIndexError as err:
-                raise JSONPatchError(
-                    f"pointer index error {err} ({op.name}:{i})"
-                ) from err
+                raise JSONPatchError(f"{err} ({op.name}:{i})") from err
             except JSONPointerTypeError as err:
-                raise JSONPatchError(
-                    f"pointer type error {err} ({op.name}:{i})"
-                ) from err
+                raise JSONPatchError(f"{err} ({op.name}:{i})") from err
             except (JSONPointerError, JSONPatchError) as err:
                 raise JSONPatchError(f"{err} ({op.name}:{i})") from err
         return _data

--- a/jsonpath/path.py
+++ b/jsonpath/path.py
@@ -79,14 +79,8 @@ class JSONPath:
             JSONPathTypeError: If a filter expression attempts to use types in
                 an incompatible way.
         """
-        if isinstance(data, str):
-            _data = json.loads(data)
-        elif isinstance(data, IOBase):
-            _data = json.loads(data.read())
-        else:
-            _data = data
         return [
-            match.obj for match in self.finditer(_data, filter_context=filter_context)
+            match.obj for match in self.finditer(data, filter_context=filter_context)
         ]
 
     def finditer(
@@ -114,6 +108,8 @@ class JSONPath:
             JSONPathTypeError: If a filter expression attempts to use types in
                 an incompatible way.
         """
+        # TODO: _load_data()
+        #  - possibly a scalar value
         if isinstance(data, str):
             _data = json.loads(data)
         elif isinstance(data, IOBase):
@@ -144,16 +140,10 @@ class JSONPath:
         filter_context: Optional[FilterContextVars] = None,
     ) -> List[object]:
         """An async version of `findall()`."""
-        if isinstance(data, str):
-            _data = json.loads(data)
-        elif isinstance(data, IOBase):
-            _data = json.loads(data.read())
-        else:
-            _data = data
         return [
             match.obj
             async for match in await self.finditer_async(
-                _data, filter_context=filter_context
+                data, filter_context=filter_context
             )
         ]
 

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -93,6 +93,8 @@ class JSONPointer:
                 .decode("utf-16")
             )
 
+        # TODO: lstrip pointer
+        # TODO: handle pointer without leading slash and not empty string
         return tuple(
             self._index(p.replace("~1", "/").replace("~0", "~")) for p in s.split("/")
         )[1:]

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -143,12 +143,12 @@ class JSONPointer:
                         try:
                             return getitem(obj, int(key))
                         except IndexError as index_err:
-                            raise JSONPointerIndexError(int(key)) from index_err
-            # TODO: include key and truncated obj
-            raise JSONPointerTypeError(str(err)) from err
+                            raise JSONPointerIndexError(
+                                f"index out of range: {key}"
+                            ) from index_err
+            raise JSONPointerTypeError(f"pointer type error: {key}: {err}") from err
         except IndexError as err:
-            # TODO: include obj name/type
-            raise JSONPointerIndexError(int(key)) from err
+            raise JSONPointerIndexError(f"index out of range: {key}") from err
 
     def resolve(
         self,

--- a/jsonpath/token.py
+++ b/jsonpath/token.py
@@ -122,4 +122,4 @@ class Token:
         """Return the line and column number for the start of this token."""
         line_number = self.value.count("\n", 0, self.index) + 1
         column_number = self.index - self.value.rfind("\n", 0, self.index)
-        return (line_number, column_number)
+        return (line_number, column_number - 1)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - Usage:
       - Quick Start: "quickstart.md"
       - Advanced Usage: "advanced.md"
+      - Command Line Interface: "cli.md"
   - Guides:
       - JSONPath Syntax: "syntax.md"
       - Filter Functions: "functions.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ select = [
   "TID",
   "YTT",
 ]
-ignore = ["S105", "S101", "D107", "D105", "PLR0913"]
+ignore = ["S105", "S101", "D107", "D105", "PLR0913", "SIM108"]
 
 fixable = ["I"]
 unfixable = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ Source = "https://github.com/jg-rp/python-jsonpath"
 [tool.hatch.version]
 path = "jsonpath/__about__.py"
 
+[project.scripts]
+json = "jsonpath.cli:main"
+
 [tool.hatch.build.targets.sdist]
 include = ["/jsonpath"]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,245 @@
+"""Test cases for the command line interface."""
+import argparse
+import json
+import pathlib
+
+import pytest
+
+from jsonpath.__about__ import __version__
+from jsonpath.cli import handle_path_command
+from jsonpath.cli import setup_parser
+from jsonpath.exceptions import JSONPathIndexError
+from jsonpath.exceptions import JSONPathSyntaxError
+from jsonpath.exceptions import JSONPathTypeError
+
+
+@pytest.fixture()
+def parser() -> argparse.ArgumentParser:
+    return setup_parser()
+
+
+@pytest.fixture()
+def invalid_target(tmp_path: pathlib.Path) -> str:
+    target_path = tmp_path / "source.json"
+    with open(target_path, "w") as fd:
+        fd.write(r"}}invalid")
+    return str(target_path)
+
+
+@pytest.fixture()
+def outfile(tmp_path: pathlib.Path) -> str:
+    output_path = tmp_path / "result.json"
+    return str(output_path)
+
+
+@pytest.fixture()
+def sample_target(tmp_path: pathlib.Path) -> str:
+    sample_data = {
+        "categories": [
+            {
+                "name": "footwear",
+                "products": [
+                    {
+                        "title": "Trainers",
+                        "description": "Fashionable trainers.",
+                        "price": 89.99,
+                    },
+                    {
+                        "title": "Barefoot Trainers",
+                        "description": "Running trainers.",
+                        "price": 130.00,
+                    },
+                ],
+            },
+            {
+                "name": "headwear",
+                "products": [
+                    {
+                        "title": "Cap",
+                        "description": "Baseball cap",
+                        "price": 15.00,
+                    },
+                    {
+                        "title": "Beanie",
+                        "description": "Winter running hat.",
+                        "price": 9.00,
+                    },
+                ],
+            },
+        ],
+        "price_cap": 10,
+    }
+
+    target_path = tmp_path / "source.json"
+    with open(target_path, "w") as fd:
+        json.dump(sample_data, fd)
+    return str(target_path)
+
+
+def test_no_sub_command(
+    parser: argparse.ArgumentParser, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test that the CLI exits without a sub command."""
+    with pytest.raises(SystemExit) as err:
+        parser.parse_args([])
+
+    captured = capsys.readouterr()
+    assert err.value.code == 2  # noqa: PLR2004
+    assert (
+        captured.err.strip()
+        == parser.format_usage()
+        + "json: error: the following arguments are required: COMMAND"
+    )
+
+
+def test_help(
+    parser: argparse.ArgumentParser, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test that the CLI can display a help message without a command."""
+    with pytest.raises(SystemExit) as err:
+        parser.parse_args(["-h"])
+
+    captured = capsys.readouterr()
+    assert err.value.code == 0
+    assert captured.out == parser.format_help()
+
+
+def test_version(
+    parser: argparse.ArgumentParser, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test that the CLI can display a version number without a command."""
+    with pytest.raises(SystemExit) as err:
+        parser.parse_args(["--version"])
+
+    captured = capsys.readouterr()
+    assert err.value.code == 0
+    assert captured.out.strip() == f"python-jsonpath, version {__version__}"
+
+
+def test_path_command_invalid_target(
+    parser: argparse.ArgumentParser,
+    invalid_target: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that we handle invalid JSON with the _path_ command."""
+    args = parser.parse_args(["path", "-q", "$.foo", "-f", invalid_target])
+
+    with pytest.raises(SystemExit) as err:
+        handle_path_command(args)
+
+    captured = capsys.readouterr()
+    assert err.value.code == 1
+    assert captured.err.startswith("target document json decode error:")
+
+
+def test_path_command_invalid_target_debug(
+    parser: argparse.ArgumentParser,
+    invalid_target: str,
+) -> None:
+    """Test that we handle invalid JSON with the _path_ command."""
+    args = parser.parse_args(["--debug", "path", "-q", "$.foo", "-f", invalid_target])
+    with pytest.raises(json.JSONDecodeError):
+        handle_path_command(args)
+
+
+def test_json_path_syntax_error(
+    parser: argparse.ArgumentParser,
+    sample_target: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that we handle a JSONPath with a syntax error."""
+    args = parser.parse_args(["path", "-q", "$.1", "-f", sample_target])
+
+    with pytest.raises(SystemExit) as err:
+        handle_path_command(args)
+
+    assert err.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.err.startswith("json path syntax error")
+
+
+def test_json_path_syntax_error_debug(
+    parser: argparse.ArgumentParser,
+    sample_target: str,
+) -> None:
+    """Test that we handle a JSONPath with a syntax error."""
+    args = parser.parse_args(["--debug", "path", "-q", "$.1", "-f", sample_target])
+    with pytest.raises(JSONPathSyntaxError):
+        handle_path_command(args)
+
+
+def test_json_path_type_error(
+    parser: argparse.ArgumentParser,
+    sample_target: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that we handle a JSONPath with a syntax error."""
+    args = parser.parse_args(
+        ["path", "-q", "$.foo[?count(@.bar, 'baz')]", "-f", sample_target]
+    )
+
+    with pytest.raises(SystemExit) as err:
+        handle_path_command(args)
+
+    captured = capsys.readouterr()
+    assert err.value.code == 1
+    assert captured.err.startswith("json path type error")
+
+
+def test_json_path_type_error_debug(
+    parser: argparse.ArgumentParser,
+    sample_target: str,
+) -> None:
+    """Test that we handle a JSONPath with a syntax error."""
+    args = parser.parse_args(
+        ["--debug", "path", "-q", "$.foo[?count(@.bar, 'baz')]", "-f", sample_target]
+    )
+
+    with pytest.raises(JSONPathTypeError):
+        handle_path_command(args)
+
+
+def test_json_path_index_error(
+    parser: argparse.ArgumentParser,
+    sample_target: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that we handle a JSONPath with a syntax error."""
+    args = parser.parse_args(["path", "-q", f"$.foo[{2**53}]", "-f", sample_target])
+
+    with pytest.raises(SystemExit) as err:
+        handle_path_command(args)
+
+    captured = capsys.readouterr()
+    assert err.value.code == 1
+    assert captured.err.startswith("json path index error")
+
+
+def test_json_path_index_error_debug(
+    parser: argparse.ArgumentParser,
+    sample_target: str,
+) -> None:
+    """Test that we handle a JSONPath with a syntax error."""
+    args = parser.parse_args(
+        ["--debug", "path", "-q", f"$.foo[{2**53}]", "-f", sample_target]
+    )
+
+    with pytest.raises(JSONPathIndexError):
+        handle_path_command(args)
+
+
+def test_json_path(
+    parser: argparse.ArgumentParser,
+    sample_target: str,
+    outfile: str,
+) -> None:
+    """Test a valid JSONPath."""
+    args = parser.parse_args(
+        ["path", "-q", "$..products.*", "-f", sample_target, "-o", outfile]
+    )
+
+    handle_path_command(args)
+    args.output.flush()
+
+    with open(outfile, "r") as fd:
+        assert len(json.load(fd)) == 4  # noqa: PLR2004


### PR DESCRIPTION
This pull request adds a command line interface, exposing JSONPath, JSON Pointer and JSON Patch features. Closes #16.

We define a `json` entry point, as well as a package `__main__.py` (`python -m jsonpath`).

**Example usage:**

Find objects in `source.json` matching a JSONPath, write them to `result.json`.
```console
$ json path -q "$.foo['bar'][?@.baz > 1]" -f source.json -o result.json
```

Resolve a JSON Pointer against `source.json`, pretty print the result to stdout.
```console
$ json --pretty pointer -p "/foo/bar/0" -f source.json
```

Apply JSON Patch `patch.json` to JSON from stdin, output to `result.json`.
```console
$ cat source.json | json patch /path/to/patch.json -o result.json
```
