### PR TITLE
Fix invalid escapes in string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Python JSONPath Change Log
 
+## Version 0.10.0 (unreleased)
+
+**Breaking Changes**
+
+- The JSONPath lexer now yields distinct tokens for single and double quoted string literals. This is so the parser can do a better job of detecting invalid escape sequences.
+
+**Fixes**
+
+- We no longer silently ignore invalid escape sequences in JSONPath string literals. For example, `$['\"']` used to be OK, it now raises a `JSONPathSyntaxError`.
+
 ## Version 0.9.0
 
 **Breaking Changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Breaking Changes**
 
 - The JSONPath lexer now yields distinct tokens for single and double quoted string literals. This is so the parser can do a better job of detecting invalid escape sequences.
+- Changed the canonical representation of a JSONPath string literal to use double quotes instead of single quotes.
 
 **Fixes**
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -193,7 +193,6 @@ And this is a list of areas where we deviate from the [IETF JSONPath draft](http
 - The root token (default `$`) is optional.
 - Paths starting with a dot (`.`) are OK. `.thing` is the same as `$.thing`, as is `thing`, `$[thing]` and `$["thing"]`.
 - The built-in `match()` and `search()` filter functions use Python's standard library `re` module, which, at least, doesn't support Unicode properties. We might add an implementation of `match()` and `search()` using the third party [regex](https://pypi.org/project/regex/) package in the future.
-- We silently ignore unnecessary escaping when parsing some quoted selectors. The standard treats this as an "invalid selector".
 
 And this is a list of features that are uncommon or unique to Python JSONPath.
 

--- a/jsonpath/filter.py
+++ b/jsonpath/filter.py
@@ -188,6 +188,9 @@ class StringLiteral(Literal[str]):
 
     __slots__ = ()
 
+    def __str__(self) -> str:
+        return json.dumps(self.value)
+
 
 class IntegerLiteral(Literal[int]):
     """An integer literal."""

--- a/jsonpath/lex.py
+++ b/jsonpath/lex.py
@@ -60,7 +60,6 @@ from .token import TOKEN_SLICE
 from .token import TOKEN_SLICE_START
 from .token import TOKEN_SLICE_STEP
 from .token import TOKEN_SLICE_STOP
-from .token import TOKEN_STRING
 from .token import TOKEN_TRUE
 from .token import TOKEN_UNDEFINED
 from .token import TOKEN_UNION
@@ -256,13 +255,13 @@ class Lexer:
                 )
             elif kind == TOKEN_DOUBLE_QUOTE_STRING:
                 yield _token(
-                    kind=TOKEN_STRING,
+                    kind=TOKEN_DOUBLE_QUOTE_STRING,
                     value=match.group("G_DQUOTE"),
                     index=match.start("G_DQUOTE"),
                 )
             elif kind == TOKEN_SINGLE_QUOTE_STRING:
                 yield _token(
-                    kind=TOKEN_STRING,
+                    kind=TOKEN_SINGLE_QUOTE_STRING,
                     value=match.group("G_SQUOTE"),
                     index=match.start("G_SQUOTE"),
                 )

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -37,10 +37,6 @@ SKIP = {
     "functions, match, filter, match function, unicode char class negated, uppercase": "\\P not supported",  # noqa: E501
     "functions, search, filter, search function, unicode char class, uppercase": "\\p not supported",  # noqa: E501
     "functions, search, filter, search function, unicode char class negated, uppercase": "\\P not supported",  # noqa: E501
-    "name selector, double quotes, invalid escaped single quote": "ignore",
-    "name selector, double quotes, incomplete escape": "ignore",
-    "name selector, single quotes, invalid escaped double quote": "ignore",
-    "name selector, single quotes, incomplete escape": "ignore",
     "filter, non-singular query in comparison, slice": "TODO",
     "filter, non-singular query in comparison, all children": "TODO",
     "filter, non-singular query in comparison, descendants": "TODO",

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -10,6 +10,7 @@ from jsonpath.token import TOKEN_AND
 from jsonpath.token import TOKEN_BARE_PROPERTY
 from jsonpath.token import TOKEN_COMMA
 from jsonpath.token import TOKEN_DDOT
+from jsonpath.token import TOKEN_DOUBLE_QUOTE_STRING
 from jsonpath.token import TOKEN_EQ
 from jsonpath.token import TOKEN_FALSE
 from jsonpath.token import TOKEN_FILTER_END
@@ -35,10 +36,10 @@ from jsonpath.token import TOKEN_RE_PATTERN
 from jsonpath.token import TOKEN_ROOT
 from jsonpath.token import TOKEN_RPAREN
 from jsonpath.token import TOKEN_SELF
+from jsonpath.token import TOKEN_SINGLE_QUOTE_STRING
 from jsonpath.token import TOKEN_SLICE_START
 from jsonpath.token import TOKEN_SLICE_STEP
 from jsonpath.token import TOKEN_SLICE_STOP
-from jsonpath.token import TOKEN_STRING
 from jsonpath.token import TOKEN_TRUE
 from jsonpath.token import TOKEN_UNION
 from jsonpath.token import TOKEN_WILD
@@ -84,7 +85,9 @@ TEST_CASES = [
         want=[
             Token(kind=TOKEN_ROOT, value="$", index=0, path='$["some"]'),
             Token(kind=TOKEN_LIST_START, value="[", index=1, path='$["some"]'),
-            Token(kind=TOKEN_STRING, value="some", index=3, path='$["some"]'),
+            Token(
+                kind=TOKEN_DOUBLE_QUOTE_STRING, value="some", index=3, path='$["some"]'
+            ),
             Token(kind=TOKEN_RBRACKET, value="]", index=8, path='$["some"]'),
         ],
     ),
@@ -94,7 +97,9 @@ TEST_CASES = [
         want=[
             Token(kind=TOKEN_ROOT, value="$", index=0, path="$['some']"),
             Token(kind=TOKEN_LIST_START, value="[", index=1, path="$['some']"),
-            Token(kind=TOKEN_STRING, value="some", index=3, path="$['some']"),
+            Token(
+                kind=TOKEN_SINGLE_QUOTE_STRING, value="some", index=3, path="$['some']"
+            ),
             Token(kind=TOKEN_RBRACKET, value="]", index=8, path="$['some']"),
         ],
     ),
@@ -754,7 +759,10 @@ TEST_CASES = [
                 kind=TOKEN_COMMA, value=",", index=16, path="[?(@.thing in [1, '1'])]"
             ),
             Token(
-                kind=TOKEN_STRING, value="1", index=19, path="[?(@.thing in [1, '1'])]"
+                kind=TOKEN_SINGLE_QUOTE_STRING,
+                value="1",
+                index=19,
+                path="[?(@.thing in [1, '1'])]",
             ),
             Token(
                 kind=TOKEN_RBRACKET,
@@ -1010,10 +1018,18 @@ TEST_CASES = [
         want=[
             Token(kind=TOKEN_ROOT, value="$", index=0, path="$['some', 'thing']"),
             Token(kind=TOKEN_LIST_START, value="[", index=1, path="$['some', 'thing']"),
-            Token(kind=TOKEN_STRING, value="some", index=3, path="$['some', 'thing']"),
+            Token(
+                kind=TOKEN_SINGLE_QUOTE_STRING,
+                value="some",
+                index=3,
+                path="$['some', 'thing']",
+            ),
             Token(kind=TOKEN_COMMA, value=",", index=8, path="$['some', 'thing']"),
             Token(
-                kind=TOKEN_STRING, value="thing", index=11, path="$['some', 'thing']"
+                kind=TOKEN_SINGLE_QUOTE_STRING,
+                value="thing",
+                index=11,
+                path="$['some', 'thing']",
             ),
             Token(kind=TOKEN_RBRACKET, value="]", index=17, path="$['some', 'thing']"),
         ],

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -108,7 +108,7 @@ TEST_CASES = [
     Case(
         description="filter with list membership test",
         path="$.some[?(@.thing in ['foo', 'bar', 42])]",
-        want="$['some'][?(@['thing'] in ['foo', 'bar', 42])]",
+        want="$['some'][?(@['thing'] in [\"foo\", \"bar\", 42])]",
     ),
     Case(
         description="filter with boolean literals",
@@ -143,7 +143,7 @@ TEST_CASES = [
     Case(
         description="filter with string literal",
         path="$.some[?(@.thing == 'foo')]",
-        want="$['some'][?(@['thing'] == 'foo')]",
+        want="$['some'][?(@['thing'] == \"foo\")]",
     ),
     Case(
         description="filter with integer literal",
@@ -169,6 +169,16 @@ TEST_CASES = [
         description="keys selector",
         path="$.some.~",
         want="$['some'][~]",
+    ),
+    Case(
+        description="comparison to single quoted string literal with escape",
+        path="$[?@.foo == 'ba\\'r']",
+        want="$[?(@['foo'] == \"ba'r\")]",
+    ),
+    Case(
+        description="comparison to double quoted string literal with escape",
+        path='$[?@.foo == "ba\\"r"]',
+        want='$[?(@[\'foo\'] == "ba\\"r")]',
     ),
 ]
 


### PR DESCRIPTION
Fix detection of invalid escape sequences in JSONPath string literals. For example, `$['\"']` used to be OK, it now raises a `JSONPathSyntaxError`.

We're also now parsing string literals that appear in comparison and function expressions similarly to bracketed name selectors. Previously non-name string literals were being passed through unchanged.

Closes #31 