### PR TITLE
Fix JSONPath operator precedence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Python JSONPath Change Log
 
+## Version 0.10.2 (unreleased)
+
+**Fixes**
+
+- Fixed precedence of the logical not operator in JSONPath filter expressions. Previously, logical _or_ and logical _and_ had priority over _not_. See [#41](https://github.com/jg-rp/python-jsonpath/issues/41).
+
 ## Version 0.10.1
 
 **Hot fix**

--- a/jsonpath/parse.py
+++ b/jsonpath/parse.py
@@ -158,7 +158,7 @@ class Parser:
         TOKEN_LG: PRECEDENCE_RELATIONAL,
         TOKEN_LT: PRECEDENCE_RELATIONAL,
         TOKEN_NE: PRECEDENCE_RELATIONAL,
-        TOKEN_NOT: PRECEDENCE_LOGICALRIGHT,
+        TOKEN_NOT: PRECEDENCE_PREFIX,
         TOKEN_OR: PRECEDENCE_LOGICAL,
         TOKEN_RE: PRECEDENCE_RELATIONAL,
         TOKEN_RPAREN: PRECEDENCE_LOWEST,
@@ -499,9 +499,7 @@ class Parser:
         assert tok.kind == TOKEN_NOT
         return PrefixExpression(
             operator="!",
-            right=self.parse_filter_selector(
-                stream, precedence=self.PRECEDENCE_LOGICALRIGHT
-            ),
+            right=self.parse_filter_selector(stream, precedence=self.PRECEDENCE_PREFIX),
         )
 
     def parse_infix_expression(

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -180,6 +180,21 @@ TEST_CASES = [
         path='$[?@.foo == "ba\\"r"]',
         want='$[?@[\'foo\'] == "ba\\"r"]',
     ),
+    Case(
+        description="not binds more tightly than or",
+        path="$[?!@.a || !@.b]",
+        want="$[?(!@['a'] || !@['b'])]",
+    ),
+    Case(
+        description="not binds more tightly than and",
+        path="$[?!@.a && !@.b]",
+        want="$[?(!@['a'] && !@['b'])]",
+    ),
+    Case(
+        description="control precedence with parens",
+        path="$[?!(@.a && !@.b)]",
+        want="$[?!(@['a'] && !@['b'])]",
+    ),
 ]
 
 


### PR DESCRIPTION
Give logical _not_ higher precedence than logical _and_ and logical _or_ in JSONPath filter expressions. Closes #41.