### PR TITLE
Fix type checks on logical expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Version 0.10.3 (unreleased)
 
+**Changes**
+
+- Changed the exception raised when attempting to compare a non-singular filter query from `JSONPathSyntaxError` to `JSONPathTypeError`.
+
 **Fixes**
 
 - Fixed handling of relative and root queries when used as arguments to filter functions. Previously, when those queries resulted in an empty node list, we were converting them to an empty regular list before passing it to functions that accept _ValueType_ arguments. Now, in such cases, we convert empty node lists to the special result _Nothing_, which is required by the spec.
+- Fixed well-typedness checks on JSONPath logical expressions (those that involve `&&` or `||`) and non-singular filter queries. Previously we were erroneously applying the checks for comparison expressions to logical expressions too. Now non-singular queries in logical expressions act as an existence test. See [#45] (https://github.com/jg-rp/python-jsonpath/issues/45).
 
 ## Version 0.10.2
 

--- a/jsonpath/__about__.py
+++ b/jsonpath/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present James Prior <jamesgr.prior@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.10.2"
+__version__ = "0.10.3"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,6 +5,7 @@ from typing import List
 import pytest
 
 from jsonpath import JSONPathEnvironment
+from jsonpath import JSONPathTypeError
 
 
 @pytest.fixture()
@@ -170,3 +171,13 @@ def test_custom_keys_selector_token() -> None:
     data = {"foo": {"a": 1, "b": 2, "c": 3}}
     assert env.findall("$.foo.*~", data) == ["a", "b", "c"]
     assert env.findall("$.foo.*", data) == [1, 2, 3]
+
+
+def test_disable_well_typed_checks() -> None:
+    """Test that we can disable checks for well-typedness."""
+    env = JSONPathEnvironment(well_typed=True)
+    with pytest.raises(JSONPathTypeError):
+        env.compile("$[?@.* > 2]")
+
+    env = JSONPathEnvironment(well_typed=False)
+    env.compile("$[?@.* > 2]")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -23,3 +23,8 @@ def test_function_missing_param(env: JSONPathEnvironment) -> None:
 def test_function_too_many_params(env: JSONPathEnvironment) -> None:
     with pytest.raises(JSONPathTypeError):
         env.compile("$[?(length(@.a, @.b)==1)]")
+
+
+def test_non_singular_query_is_not_comparable(env: JSONPathEnvironment) -> None:
+    with pytest.raises(JSONPathTypeError):
+        env.compile("$[?@.* > 2]")


### PR DESCRIPTION
This PR fixes well-typedness checks on JSONPath logical expressions (those that involve `&&` or `||`) with non-singular filter queries.

Closes #45.