### PR TITLE
Add a fluent API for JSONPathMatch iterators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Python JSONPath Change Log
 
+## Version 1.1.0 (unreleased)
+
+**Features**
+
+- Added the "query API", a fluent, chainable API for manipulating `JSONPathMatch` iterators.
+
 ## Version 1.0.0
 
 [RFC 9535](https://datatracker.ietf.org/doc/html/rfc9535) (JSONPath: Query Expressions for JSON) is now out, replacing the [draft IETF JSONPath base](https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base-21).

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,9 @@
 ::: jsonpath.CompoundJSONPath
     handler: python
 
+::: jsonpath.Query
+    handler: python
+
 ::: jsonpath.function_extensions.FilterFunction
     handler: python
 

--- a/docs/query.md
+++ b/docs/query.md
@@ -24,6 +24,23 @@ for value in values:
     # ...
 ```
 
+`Query` objects are iterable and can only be iterated once. Pass the query to `list()` (or other sequence) to get a list of results that can be iterated multiple times or otherwise manipulated.
+
+```python
+from jsonpath import query
+
+# data = ...
+
+values = list(
+    query("$.some[?@.thing]", data)
+    .skip(5)
+    .limit(10)
+    .values()
+)
+
+print(values[1])
+```
+
 ## Chainable methods
 
 The following `Query` methods all return `self` (the same `Query` instance), so method calls can be chained to further manipulate the underlying iterator.

--- a/docs/query.md
+++ b/docs/query.md
@@ -1,0 +1,61 @@
+# Query Iterators
+
+**_New in version 1.1.0_**
+
+In addition to [`findall()`](api.md#jsonpath.JSONPathEnvironment.findall) and [`finditer()`](api.md#jsonpath.JSONPathEnvironment.finditer), covered in the [quick start guide](./quickstart.md), Python JSONPath offers a fluent _query_ iterator interface.
+
+[`Query`](api.md#jsonpath.Query) objects provide chainable methods for manipulating a [`JSONPathMatch`](api.md#jsonpath.JSONPathMatch) iterator, just like you'd get from `finditer()`. Obtain a `Query` object using the package-level `query()` function or [`JSONPathEnvironment.query()`](api.md#jsonpath.JSONPathEnvironment.query).
+
+This example uses the query API to skip the first 5 matches, limit the total number of matches to 10, and get the value associated with each match.
+
+```python
+from jsonpath import query
+
+# data = ...
+
+values = (
+    query("$.some[?@.thing]", data)
+    .skip(5)
+    .limit(10)
+    .values()
+)
+
+for value in values:
+    # ...
+```
+
+## Chainable methods
+
+The following `Query` methods all return `self` (the same `Query` instance), so method calls can be chained to further manipulate the underlying iterator.
+
+| Method          | Aliases                 | Description                                        |
+| --------------- | ----------------------- | -------------------------------------------------- |
+| `skip(n: int)`  | `drop`                  | Drop up to _n_ matches from the iterator.          |
+| `limit(n: int)` | `head`, `take`, `first` | Yield at most _n_ matches from the iterator.       |
+| `tail(n: int)`  | `last`                  | Drop matches from the iterator up to the last _n_. |
+
+## Terminal methods
+
+These are terminal methods of the `Query` class. They can not be chained.
+
+| Method        | Aliases | Description                                                                                 |
+| ------------- | ------- | ------------------------------------------------------------------------------------------- |
+| `values()`    |         | Return an iterable of objects, one for each match in the iterable.                          |
+| `locations()` |         | Return an iterable of normalized paths, one for each match in the iterable.                 |
+| `items()`     |         | Return an iterable of (object, normalized path) tuples, one for each match in the iterable. |
+| `pointers()`  |         | Return an iterable of `JSONPointer` instances, one for each match in the iterable.          |
+| `first_one()` | `one`   | Return the first `JSONPathMatch`, or `None` if there were no matches.                       |
+| `last_one()`  |         | Return the last `JSONPathMatch`, or `None` if there were no matches.                        |
+
+## Tee
+
+And finally there's `tee()`, which creates multiple independent queries from one query iterator. It is not safe to use the initial `Query` instance after calling `tee()`.
+
+```python
+from jsonpath import query
+
+it1, it2 = query("$.some[?@.thing]", data).tee()
+
+head = it1.head(10) # first 10 matches
+tail = it2.tail(10) # last 10 matches
+```

--- a/docs/query.md
+++ b/docs/query.md
@@ -6,7 +6,7 @@ In addition to [`findall()`](api.md#jsonpath.JSONPathEnvironment.findall) and [`
 
 [`Query`](api.md#jsonpath.Query) objects provide chainable methods for manipulating a [`JSONPathMatch`](api.md#jsonpath.JSONPathMatch) iterator, just like you'd get from `finditer()`. Obtain a `Query` object using the package-level `query()` function or [`JSONPathEnvironment.query()`](api.md#jsonpath.JSONPathEnvironment.query).
 
-This example uses the query API to skip the first 5 matches, limit the total number of matches to 10, and get the value associated with each match.
+This example uses the query API to skip the first five matches, limit the total number of matches to ten, and get the value associated with each match.
 
 ```python
 from jsonpath import query

--- a/docs/query.md
+++ b/docs/query.md
@@ -45,11 +45,11 @@ print(values[1])
 
 The following `Query` methods all return `self` (the same `Query` instance), so method calls can be chained to further manipulate the underlying iterator.
 
-| Method          | Aliases                 | Description                                        |
-| --------------- | ----------------------- | -------------------------------------------------- |
-| `skip(n: int)`  | `drop`                  | Drop up to _n_ matches from the iterator.          |
-| `limit(n: int)` | `head`, `take`, `first` | Yield at most _n_ matches from the iterator.       |
-| `tail(n: int)`  | `last`                  | Drop matches from the iterator up to the last _n_. |
+| Method          | Aliases         | Description                                        |
+| --------------- | --------------- | -------------------------------------------------- |
+| `skip(n: int)`  | `drop`          | Drop up to _n_ matches from the iterator.          |
+| `limit(n: int)` | `head`, `first` | Yield at most _n_ matches from the iterator.       |
+| `tail(n: int)`  | `last`          | Drop matches from the iterator up to the last _n_. |
 
 ## Terminal methods
 
@@ -63,6 +63,22 @@ These are terminal methods of the `Query` class. They can not be chained.
 | `pointers()`  |         | Return an iterable of `JSONPointer` instances, one for each match in the iterable.          |
 | `first_one()` | `one`   | Return the first `JSONPathMatch`, or `None` if there were no matches.                       |
 | `last_one()`  |         | Return the last `JSONPathMatch`, or `None` if there were no matches.                        |
+
+## Take
+
+[`Query.take(self, n: int)`](api.md#jsonpath.Query.take) returns a new `Query` instance, iterating over the next _n_ matches. It leaves the existing query in a safe state, ready to resume iteration of remaining matches.
+
+```python
+from jsonpath import query
+
+it = query("$.some.*", {"some": [0, 1, 2, 3]})
+
+for match in it.take(2):
+    print(match.value)  # 0, 1
+
+for value in it.values():
+    print(value)  # 2, 3
+```
 
 ## Tee
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -294,7 +294,7 @@ print(data)  # {'some': {'other': 'thing', 'foo': {'bar': [1], 'else': 'thing'}}
 
 ## What's Next?
 
-Read about user-defined filter functions at [Function Extensions](advanced.md#function-extensions), or see how to make extra data available to filters with [Extra Filter Context](advanced.md#extra-filter-context).
+Read about the [Query Iterators](query.md) API or [user-defined filter functions](advanced.md#function-extensions). Also see how to make extra data available to filters with [Extra Filter Context](advanced.md#extra-filter-context).
 
 `findall()`, `finditer()` and `compile()` are shortcuts that use the default[`JSONPathEnvironment`](api.md#jsonpath.JSONPathEnvironment). `jsonpath.findall(path, data)` is equivalent to:
 

--- a/jsonpath/__init__.py
+++ b/jsonpath/__init__.py
@@ -74,6 +74,4 @@ findall_async = DEFAULT_ENV.findall_async
 finditer = DEFAULT_ENV.finditer
 finditer_async = DEFAULT_ENV.finditer_async
 match = DEFAULT_ENV.match
-first = DEFAULT_ENV.match
 query = DEFAULT_ENV.query
-find = DEFAULT_ENV.query

--- a/jsonpath/__init__.py
+++ b/jsonpath/__init__.py
@@ -17,6 +17,7 @@ from .exceptions import RelativeJSONPointerError
 from .exceptions import RelativeJSONPointerIndexError
 from .exceptions import RelativeJSONPointerSyntaxError
 from .filter import UNDEFINED
+from .fluent_api import Query
 from .lex import Lexer
 from .match import JSONPathMatch
 from .parse import Parser
@@ -58,6 +59,7 @@ __all__ = (
     "RelativeJSONPointerSyntaxError",
     "resolve",
     "UNDEFINED",
+    "Query",
 )
 
 
@@ -69,3 +71,6 @@ findall_async = DEFAULT_ENV.findall_async
 finditer = DEFAULT_ENV.finditer
 finditer_async = DEFAULT_ENV.finditer_async
 match = DEFAULT_ENV.match
+first = DEFAULT_ENV.match
+query = DEFAULT_ENV.query
+find = DEFAULT_ENV.query

--- a/jsonpath/__init__.py
+++ b/jsonpath/__init__.py
@@ -31,10 +31,12 @@ from .pointer import resolve
 __all__ = (
     "compile",
     "CompoundJSONPath",
+    "find",
     "findall_async",
     "findall",
     "finditer_async",
     "finditer",
+    "first",
     "JSONPatch",
     "JSONPath",
     "JSONPathEnvironment",
@@ -53,13 +55,14 @@ __all__ = (
     "Lexer",
     "match",
     "Parser",
+    "query",
+    "Query",
     "RelativeJSONPointer",
     "RelativeJSONPointerError",
     "RelativeJSONPointerIndexError",
     "RelativeJSONPointerSyntaxError",
     "resolve",
     "UNDEFINED",
-    "Query",
 )
 
 

--- a/jsonpath/fluent_api.py
+++ b/jsonpath/fluent_api.py
@@ -6,6 +6,7 @@ import itertools
 from typing import TYPE_CHECKING
 from typing import Iterable
 from typing import Iterator
+from typing import List
 from typing import Optional
 from typing import Tuple
 
@@ -33,47 +34,37 @@ class Query:
     def __iter__(self) -> Iterator[JSONPathMatch]:
         return self._it
 
-    def take(self, n: int) -> Query:
+    def limit(self, n: int) -> Query:
         """Limit the query iterator to at most _n_ matches.
 
         Raises:
             ValueError: If _n_ < 0.
         """
         if n < 0:
-            raise ValueError("can't take a negative number of matches")
+            raise ValueError("can't limit by a negative number of matches")
 
         self._it = itertools.islice(self._it, n)
         return self
 
-    def limit(self, n: int) -> Query:
-        """Limit the query iterator to at most _n_ matches.
-
-        `limit()` is an alias of `take()`.
-
-        Raises:
-            ValueError: If _n_ < 0.
-        """
-        return self.take(n)
-
     def head(self, n: int) -> Query:
         """Limit the query iterator to at most the first _n_ matches.
 
-        `head()` is an alias for `take()`.
+        `head()` is an alias for `limit()`.
 
         Raises:
             ValueError: If _n_ < 0.
         """
-        return self.take(n)
+        return self.limit(n)
 
     def first(self, n: int) -> Query:
         """Limit the query iterator to at most the first _n_ matches.
 
-        `first()` is an alias for `take()`.
+        `first()` is an alias for `limit()`.
 
         Raises:
             ValueError: If _n_ < 0.
         """
-        return self.take(n)
+        return self.limit(n)
 
     def drop(self, n: int) -> Query:
         """Skip up to _n_ matches from the query iterator.
@@ -162,3 +153,10 @@ class Query:
         It is not safe to use a `Query` instance after calling `tee()`.
         """
         return tuple(Query(it) for it in itertools.tee(self._it, n))
+
+    def take(self, n: int) -> Query:
+        """Return a new query iterating over the next _n_ matches.
+
+        It is safe to continue using this query after calling take.
+        """
+        return Query(list(itertools.islice(self._it, n)))

--- a/jsonpath/fluent_api.py
+++ b/jsonpath/fluent_api.py
@@ -130,6 +130,8 @@ class Query:
         """Return an iterable of (object, normalized path) tuples for each match."""
         return ((m.path, m.obj) for m in self._it)
 
+    # TODO: def pointers
+
     def first_one(self) -> Optional[JSONPathMatch]:
         """Return the first `JSONPathMatch` or `None` if there were no matches."""
         try:
@@ -152,7 +154,7 @@ class Query:
             return None
 
     def tee(self, n: int = 2) -> Tuple[Query, ...]:
-        """Return _n_ independent queries by teeing this query's match iterable.
+        """Return _n_ independent queries by teeing this query's iterator.
 
         It is not safe to use a `Query` instance after calling `tee()`.
         """

--- a/jsonpath/fluent_api.py
+++ b/jsonpath/fluent_api.py
@@ -33,7 +33,7 @@ class Query:
         return self._it
 
     def take(self, n: int) -> Query:
-        """Limit the result set to at most _n_ matches.
+        """Limit the query iterator to at most _n_ matches.
 
         Raises:
             ValueError: If _n_ < 0.
@@ -45,7 +45,7 @@ class Query:
         return self
 
     def limit(self, n: int) -> Query:
-        """Limit the result set to at most _n_ matches.
+        """Limit the query iterator to at most _n_ matches.
 
         `limit()` is an alias of `take()`.
 
@@ -55,7 +55,7 @@ class Query:
         return self.take(n)
 
     def head(self, n: int) -> Query:
-        """Take the first _n_ matches.
+        """Limit the query iterator to at most the first _n_ matches.
 
         `head()` is an alias for `take()`.
 
@@ -64,8 +64,18 @@ class Query:
         """
         return self.take(n)
 
+    def first(self, n: int) -> Query:
+        """Limit the query iterator to at most the first _n_ matches.
+
+        `first()` is an alias for `take()`.
+
+        Raises:
+            ValueError: If _n_ < 0.
+        """
+        return self.take(n)
+
     def drop(self, n: int) -> Query:
-        """Skip up to _n_ matches from the result set.
+        """Skip up to _n_ matches from the query iterator.
 
         Raises:
             ValueError: If _n_ < 0.
@@ -79,7 +89,7 @@ class Query:
         return self
 
     def skip(self, n: int) -> Query:
-        """Skip up to _n_ matches from the result set.
+        """Skip up to _n_ matches from the query iterator.
 
         Raises:
             ValueError: If _n_ < 0.
@@ -87,7 +97,7 @@ class Query:
         return self.drop(n)
 
     def tail(self, n: int) -> Query:
-        """Drop matches up to the last _n_ matches.
+        """Drop matches up to the last _n_ matches from the iterator.
 
         Raises:
             ValueError: If _n_ < 0.
@@ -97,6 +107,16 @@ class Query:
 
         self._it = iter(collections.deque(self._it, maxlen=n))
         return self
+
+    def last(self, n: int) -> Query:
+        """Drop up to the last _n_ matches from the iterator.
+
+        `last()` is an alias for `tail()`.
+
+        Raises:
+            ValueError: If _n_ < 0.
+        """
+        return self.tail(n)
 
     def values(self) -> Iterable[object]:
         """Return an iterable of objects associated with each match."""
@@ -110,14 +130,21 @@ class Query:
         """Return an iterable of (object, normalized path) tuples for each match."""
         return ((m.path, m.obj) for m in self._it)
 
-    def first(self) -> Optional[JSONPathMatch]:
+    def first_one(self) -> Optional[JSONPathMatch]:
         """Return the first `JSONPathMatch` or `None` if there were no matches."""
         try:
             return next(self._it)
         except StopIteration:
             return None
 
-    def last(self) -> Optional[JSONPathMatch]:
+    def one(self) -> Optional[JSONPathMatch]:
+        """Return the first `JSONPathMatch` or `None` if there were no matches.
+
+        `one()` is an alias for `first_one()`.
+        """
+        return self.first_one()
+
+    def last_one(self) -> Optional[JSONPathMatch]:
         """Return the last `JSONPathMatch` or `None` if there were no matches."""
         try:
             return next(iter(self.tail(1)))

--- a/jsonpath/fluent_api.py
+++ b/jsonpath/fluent_api.py
@@ -1,0 +1,125 @@
+"""A fluent API for managing JSONPathMatch iterators."""
+from __future__ import annotations
+
+import collections
+import itertools
+from typing import TYPE_CHECKING
+from typing import Iterable
+from typing import Iterator
+from typing import Optional
+from typing import Tuple
+
+if TYPE_CHECKING:
+    from jsonpath import JSONPathMatch
+
+
+class Query:
+    """A fluent API for managing `JSONPathMatch` iterators.
+
+    Usually you'll want to use `jsonpath.query()` or `JSONPathEnvironment.query()`
+    to create instances of `Query` rather than instantiating `Query` directly.
+
+    Arguments:
+        it: A `JSONPathMatch` iterable, as you'd get from `jsonpath.finditer()` or
+            `JSONPathEnvironment.finditer()`.
+
+    **New in version 1.1.0**
+    """
+
+    def __init__(self, it: Iterable[JSONPathMatch]) -> None:
+        self._it = iter(it)
+
+    def __iter__(self) -> Iterator[JSONPathMatch]:
+        return self._it
+
+    def take(self, n: int) -> Query:
+        """Limit the result set to at most _n_ matches.
+
+        Raises:
+            ValueError: If _n_ < 0.
+        """
+        if n < 0:
+            raise ValueError("can't take a negative number of matches")
+
+        self._it = itertools.islice(self._it, n)
+        return self
+
+    def limit(self, n: int) -> Query:
+        """Limit the result set to at most _n_ matches.
+
+        `limit()` is an alias of `take()`.
+
+        Raises:
+            ValueError: If _n_ < 0.
+        """
+        return self.take(n)
+
+    def head(self, n: int) -> Query:
+        """Take the first _n_ matches.
+
+        `head()` is an alias for `take()`.
+
+        Raises:
+            ValueError: If _n_ < 0.
+        """
+        return self.take(n)
+
+    def drop(self, n: int) -> Query:
+        """Skip up to _n_ matches from the result set.
+
+        Raises:
+            ValueError: If _n_ < 0.
+        """
+        if n < 0:
+            raise ValueError("can't drop a negative number of matches")
+
+        if n > 0:
+            next(itertools.islice(self._it, n, n), None)
+
+        return self
+
+    def skip(self, n: int) -> Query:
+        """Skip up to _n_ matches from the result set.
+
+        Raises:
+            ValueError: If _n_ < 0.
+        """
+        return self.drop(n)
+
+    def tail(self, n: int) -> Query:
+        """Drop matches up to the last _n_ matches.
+
+        Raises:
+            ValueError: If _n_ < 0.
+        """
+        if n < 0:
+            raise ValueError("can't select a negative number of matches")
+
+        self._it = iter(collections.deque(self._it, maxlen=n))
+        return self
+
+    def values(self) -> Iterable[object]:
+        """Return an iterable of objects associated with each match."""
+        return (m.obj for m in self._it)
+
+    def locations(self) -> Iterable[str]:
+        """Return an iterable of normalized paths for each match."""
+        return (m.path for m in self._it)
+
+    def items(self) -> Iterable[Tuple[str, object]]:
+        """Return an iterable of (object, normalized path) tuples for each match."""
+        return ((m.path, m.obj) for m in self._it)
+
+    def first(self) -> Optional[JSONPathMatch]:
+        """Return the first `JSONPathMatch` or `None` if there were no matches."""
+        try:
+            return next(self._it)
+        except StopIteration:
+            return None
+
+    def last(self) -> Optional[JSONPathMatch]:
+        """Return the last `JSONPathMatch` or `None` if there were no matches."""
+        try:
+            return next(iter(self.tail(1)))
+        except StopIteration:
+            return None

--- a/jsonpath/fluent_api.py
+++ b/jsonpath/fluent_api.py
@@ -11,6 +11,7 @@ from typing import Tuple
 
 if TYPE_CHECKING:
     from jsonpath import JSONPathMatch
+    from jsonpath import JSONPointer
 
 
 class Query:
@@ -123,14 +124,16 @@ class Query:
         return (m.obj for m in self._it)
 
     def locations(self) -> Iterable[str]:
-        """Return an iterable of normalized paths for each match."""
+        """Return an iterable of normalized paths, one for each match."""
         return (m.path for m in self._it)
 
     def items(self) -> Iterable[Tuple[str, object]]:
-        """Return an iterable of (object, normalized path) tuples for each match."""
+        """Return an iterable of (object, path) tuples, one for each match."""
         return ((m.path, m.obj) for m in self._it)
 
-    # TODO: def pointers
+    def pointers(self) -> Iterable[JSONPointer]:
+        """Return an iterable of JSONPointers, one for each match."""
+        return (m.pointer() for m in self._it)
 
     def first_one(self) -> Optional[JSONPathMatch]:
         """Return the first `JSONPathMatch` or `None` if there were no matches."""

--- a/jsonpath/fluent_api.py
+++ b/jsonpath/fluent_api.py
@@ -123,3 +123,10 @@ class Query:
             return next(iter(self.tail(1)))
         except StopIteration:
             return None
+
+    def tee(self, n: int = 2) -> Tuple[Query, ...]:
+        """Return _n_ independent queries by teeing this query's match iterable.
+
+        It is not safe to use a `Query` instance after calling `tee()`.
+        """
+        return tuple(Query(it) for it in itertools.tee(self._it, n))

--- a/jsonpath/fluent_api.py
+++ b/jsonpath/fluent_api.py
@@ -6,7 +6,6 @@ import itertools
 from typing import TYPE_CHECKING
 from typing import Iterable
 from typing import Iterator
-from typing import List
 from typing import Optional
 from typing import Tuple
 

--- a/jsonpath/match.py
+++ b/jsonpath/match.py
@@ -76,6 +76,11 @@ class JSONPathMatch:
         """Return a `JSONPointer` pointing to this match's path."""
         return JSONPointer.from_match(self)
 
+    @property
+    def value(self) -> object:
+        """Return the value associated with this match/node."""
+        return self.obj
+
 
 def _truncate(val: str, num: int, end: str = "...") -> str:
     # Replaces consecutive whitespace with a single newline.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - Guides:
       - JSONPath Syntax: "syntax.md"
       - Filter Functions: "functions.md"
+      - Query Iterators: "query.md"
       - JSON Pointers: "pointers.md"
       - Async Support: "async.md"
   - API Reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,38 @@ warn_unreachable = true
 
 
 [tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "__pypackages__",
+  "_build",
+  "buck-out",
+  "build",
+  "dist",
+  "node_modules",
+  "venv",
+]
+
+# Same as Black.
+line-length = 88
+
+
+# Assume Python 3.10.
+target-version = "py310"
+
+[tool.ruff.lint]
 select = [
   "A",
   "ARG",
@@ -134,52 +166,23 @@ select = [
   "TID",
   "YTT",
 ]
+
 ignore = ["S105", "S101", "D107", "D105", "PLR0913", "SIM108"]
 
 fixable = ["I"]
 unfixable = []
 
-# Exclude a variety of commonly ignored directories.
-exclude = [
-  ".bzr",
-  ".direnv",
-  ".eggs",
-  ".git",
-  ".hg",
-  ".mypy_cache",
-  ".nox",
-  ".pants.d",
-  ".pytype",
-  ".ruff_cache",
-  ".svn",
-  ".tox",
-  ".venv",
-  "__pypackages__",
-  "_build",
-  "buck-out",
-  "build",
-  "dist",
-  "node_modules",
-  "venv",
-]
-
-# Same as Black.
-line-length = 88
-
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
-
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "jsonpath/__about__.py" = ["D100"]
 "jsonpath/__init__.py" = ["D104"]
 "tests/*" = ["D100", "D101", "D104", "D103"]

--- a/tests/consensus.py
+++ b/tests/consensus.py
@@ -44,8 +44,8 @@ RENAME_MAP = {
 }
 
 SKIP = {
-    "bracket_notation_with_number_on_object": "Bad consensus",
-    "dot_notation_with_number_-1": "Unexpected token",
+    "bracket_notation_with_number_on_object": "We support unquoted property names",
+    "dot_notation_with_number_-1": "conflict with compliance",
     "dot_notation_with_number_on_object": "conflict with compliance",
 }
 

--- a/tests/test_fluent_api.py
+++ b/tests/test_fluent_api.py
@@ -2,6 +2,7 @@
 import pytest
 
 from jsonpath import JSONPathMatch
+from jsonpath import JSONPointer
 from jsonpath import query
 
 
@@ -240,3 +241,10 @@ def test_query_tee() -> None:
     rv2 = it2.skip(2).one()
     assert rv2 is not None
     assert rv2.value == 2  # noqa: PLR2004
+
+
+def test_query_pointers() -> None:
+    """Test that we can get pointers from a query."""
+    pointers = list(query("$.some.*", {"some": [0, 1, 2, 3]}).pointers())
+    assert len(pointers) == 4  # noqa: PLR2004
+    assert pointers[0] == JSONPointer("/some/0")

--- a/tests/test_fluent_api.py
+++ b/tests/test_fluent_api.py
@@ -85,3 +85,95 @@ def test_query_drop() -> None:
     matches = list(it)
     assert len(matches) == 2  # noqa: PLR2004
     assert [m.obj for m in matches] == [2, 3]
+
+
+def test_query_limit() -> None:
+    """Test that we can limit the number of matches."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).limit(2)
+    matches = list(it)
+    assert len(matches) == 2  # noqa: PLR2004
+    assert [m.obj for m in matches] == [0, 1]
+
+
+def test_query_limit_zero() -> None:
+    """Test that we can call limit with zero."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).limit(0)
+    matches = list(it)
+    assert len(matches) == 0  # noqa: PLR2004
+    assert [m.obj for m in matches] == []
+
+
+def test_query_limit_more() -> None:
+    """Test that we can give limit a number greater than the number of matches."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).limit(5)
+    matches = list(it)
+    assert len(matches) == 4  # noqa: PLR2004
+    assert [m.obj for m in matches] == [0, 1, 2, 3]
+
+
+def test_query_limit_all() -> None:
+    """Test limit is number of matches."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).limit(4)
+    matches = list(it)
+    assert len(matches) == 4  # noqa: PLR2004
+    assert [m.obj for m in matches] == [0, 1, 2, 3]
+
+
+def test_query_limit_negative() -> None:
+    """Test that we get an exception if limit is negative."""
+    with pytest.raises(ValueError, match="can't take a negative number of matches"):
+        query("$.some.*", {"some": [0, 1, 2, 3]}).limit(-1)
+
+
+def test_query_take() -> None:
+    """Test that we can limit the number of matches with `take`."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).take(2)
+    matches = list(it)
+    assert len(matches) == 2  # noqa: PLR2004
+    assert [m.obj for m in matches] == [0, 1]
+
+
+def test_query_head() -> None:
+    """Test that we can limit the number of matches with `head`."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).head(2)
+    matches = list(it)
+    assert len(matches) == 2  # noqa: PLR2004
+    assert [m.obj for m in matches] == [0, 1]
+
+
+def test_query_tail() -> None:
+    """Test that we can get the last _n_ matches."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).tail(2)
+    matches = list(it)
+    assert len(matches) == 2  # noqa: PLR2004
+    assert [m.obj for m in matches] == [2, 3]
+
+
+def test_query_tail_zero() -> None:
+    """Test that we can call `tail` with zero."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).tail(0)
+    matches = list(it)
+    assert len(matches) == 0  # noqa: PLR2004
+    assert [m.obj for m in matches] == []
+
+
+def test_query_tail_all() -> None:
+    """Test tail is the same as the number of matches."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).tail(4)
+    matches = list(it)
+    assert len(matches) == 4  # noqa: PLR2004
+    assert [m.obj for m in matches] == [0, 1, 2, 3]
+
+
+def test_query_tail_more() -> None:
+    """Test tail is more than the number of matches."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).tail(5)
+    matches = list(it)
+    assert len(matches) == 4  # noqa: PLR2004
+    assert [m.obj for m in matches] == [0, 1, 2, 3]
+
+
+def test_query_tail_negative() -> None:
+    """Test that we get an exception if tail is given a negative integer."""
+    with pytest.raises(ValueError, match="can't select a negative number of matches"):
+        query("$.some.*", {"some": [0, 1, 2, 3]}).tail(-1)

--- a/tests/test_fluent_api.py
+++ b/tests/test_fluent_api.py
@@ -249,3 +249,21 @@ def test_query_take() -> None:
     assert len(head) == 2  # noqa: PLR2004
     assert head == [0, 1]
     assert list(it.values()) == [2, 3]
+
+
+def test_query_take_all() -> None:
+    """Test that we can take all matches from a query iterable."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]})
+    head = list(it.take(4).values())
+    assert len(head) == 4  # noqa: PLR2004
+    assert head == [0, 1, 2, 3]
+    assert list(it.values()) == []
+
+
+def test_query_take_more() -> None:
+    """Test that we can take more matches than there are nodes."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]})
+    head = list(it.take(5).values())
+    assert len(head) == 4  # noqa: PLR2004
+    assert head == [0, 1, 2, 3]
+    assert list(it.values()) == []

--- a/tests/test_fluent_api.py
+++ b/tests/test_fluent_api.py
@@ -123,16 +123,8 @@ def test_query_limit_all() -> None:
 
 def test_query_limit_negative() -> None:
     """Test that we get an exception if limit is negative."""
-    with pytest.raises(ValueError, match="can't take a negative number of matches"):
+    with pytest.raises(ValueError, match="can't limit by a negative number of matches"):
         query("$.some.*", {"some": [0, 1, 2, 3]}).limit(-1)
-
-
-def test_query_take() -> None:
-    """Test that we can limit the number of matches with `take`."""
-    it = query("$.some.*", {"some": [0, 1, 2, 3]}).take(2)
-    matches = list(it)
-    assert len(matches) == 2  # noqa: PLR2004
-    assert [m.obj for m in matches] == [0, 1]
 
 
 def test_query_head() -> None:
@@ -248,3 +240,12 @@ def test_query_pointers() -> None:
     pointers = list(query("$.some.*", {"some": [0, 1, 2, 3]}).pointers())
     assert len(pointers) == 4  # noqa: PLR2004
     assert pointers[0] == JSONPointer("/some/0")
+
+
+def test_query_take() -> None:
+    """Test that we can take matches from a query iterable."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]})
+    head = list(it.take(2).values())
+    assert len(head) == 2  # noqa: PLR2004
+    assert head == [0, 1]
+    assert list(it.values()) == [2, 3]

--- a/tests/test_fluent_api.py
+++ b/tests/test_fluent_api.py
@@ -1,0 +1,87 @@
+"""Test cases for the fluent API."""
+import pytest
+
+from jsonpath import query
+
+
+def test_iter_query() -> None:
+    """Test that `query` result is iterable, just like `finditer`."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]})
+    for i, match in enumerate(it):
+        assert match.value == i
+
+    assert [m.obj for m in query("$.some.*", {"some": [0, 1, 2, 3]})] == [0, 1, 2, 3]
+
+
+def test_query_values() -> None:
+    """Test that we can get an iterable of values from a query."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).values()
+    assert list(it) == [0, 1, 2, 3]
+
+
+def test_query_locations() -> None:
+    """Test that we can get an iterable of paths from a query."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).locations()
+    assert list(it) == [
+        "$['some'][0]",
+        "$['some'][1]",
+        "$['some'][2]",
+        "$['some'][3]",
+    ]
+
+
+def test_query_items() -> None:
+    """Test that we can get an iterable of values and paths from a query."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).items()
+    assert list(it) == [
+        ("$['some'][0]", 0),
+        ("$['some'][1]", 1),
+        ("$['some'][2]", 2),
+        ("$['some'][3]", 3),
+    ]
+
+
+def test_query_skip() -> None:
+    """Test that we can skip matches from the start of a query iterable."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).skip(2)
+    matches = list(it)
+    assert len(matches) == 2  # noqa: PLR2004
+    assert [m.obj for m in matches] == [2, 3]
+
+
+def test_query_skip_zero() -> None:
+    """Test that we can skip zero matches from the start of a query iterable."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).skip(0)
+    matches = list(it)
+    assert len(matches) == 4  # noqa: PLR2004
+    assert [m.obj for m in matches] == [0, 1, 2, 3]
+
+
+def test_query_skip_negative() -> None:
+    """Test that we get an exception when skipping a negative value."""
+    with pytest.raises(ValueError, match="can't drop a negative number of matches"):
+        query("$.some.*", {"some": [0, 1, 2, 3]}).skip(-1)
+
+
+def test_query_skip_all() -> None:
+    """Test that we can skip all matches from the start of a query iterable."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).skip(4)
+    matches = list(it)
+    assert len(matches) == 0  # noqa: PLR2004
+    assert [m.obj for m in matches] == []
+
+
+def test_query_skip_more() -> None:
+    """Test that we can skip more results than there are matches."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).skip(5)
+    matches = list(it)
+    assert len(matches) == 0  # noqa: PLR2004
+    assert [m.obj for m in matches] == []
+
+
+def test_query_drop() -> None:
+    """Test that we can skip matches with `drop`."""
+    it = query("$.some.*", {"some": [0, 1, 2, 3]}).drop(2)
+    matches = list(it)
+    assert len(matches) == 2  # noqa: PLR2004
+    assert [m.obj for m in matches] == [2, 3]


### PR DESCRIPTION
The PR adds a package-level `query()` function and `JSONPathEnvironment.query()`, each returning a `Query` object. `Query` objects provide chainable methods for manipulating a `JSONPathMatch` iterator.

This example uses the query API to skip the first 5 matches, limit the total number of matches to 10, and get the value associated with each match.

```python
from jsonpath import query

# data = ...

values = (
    query("$.some[?@.thing]", data)
    .skip(5)
    .limit(10)
    .values()
)

for value in values:
    # ...
```

Closes #52 