### PR TITLE
Fix operator precedence and selector list order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 1.1.0 (unreleased)
 
+**Fixes**
+
+- Fixed logical operator precedence in JSONPath filter expressions. Previously, logical _or_ (`||`) logical _and_ (`&&`) had equal precedence. Now `&&` binds more tightly than `||`, as per RFC 9535.
+- Fixed bracketed selector list evaluation order. Previously we were iterating nodes for every list item, now we exhaust all matches for the first item before moving on to the next item.
+
 **Features**
 
 - Added the "query API", a fluent, chainable API for manipulating `JSONPathMatch` iterators.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -209,6 +209,7 @@ And this is a list of areas where we deviate from [RFC 9535](https://datatracker
 - We don't require the recursive descent segment to have a selector. `$..` is equivalent to `$..*`.
 - We support explicit comparisons to `undefined` as well as implicit existence tests.
 - Float literals without a fractional digit are OK. `1.` is equivalent to `1.0`.
+- We treat literals (such as `true` and `false`) as valid "basic" expressions. So `$[?true || false]` does not raise a syntax error, which is and invalid query according to RFC 9535.
 
 And this is a list of features that are uncommon or unique to Python JSONPath.
 

--- a/jsonpath/filter.py
+++ b/jsonpath/filter.py
@@ -1,4 +1,5 @@
 """Filter expression nodes."""
+
 from __future__ import annotations
 
 import copy

--- a/jsonpath/parse.py
+++ b/jsonpath/parse.py
@@ -1,4 +1,5 @@
 """The default JSONPath parser."""
+
 from __future__ import annotations
 
 import json
@@ -142,14 +143,15 @@ class Parser:
     """A JSONPath parser bound to a JSONPathEnvironment."""
 
     PRECEDENCE_LOWEST = 1
-    PRECEDENCE_LOGICALRIGHT = 3
-    PRECEDENCE_LOGICAL = 4
+    PRECEDENCE_LOGICALRIGHT = 2
+    PRECEDENCE_LOGICAL_OR = 3
+    PRECEDENCE_LOGICAL_AND = 4
     PRECEDENCE_RELATIONAL = 5
     PRECEDENCE_MEMBERSHIP = 6
     PRECEDENCE_PREFIX = 7
 
     PRECEDENCES = {
-        TOKEN_AND: PRECEDENCE_LOGICAL,
+        TOKEN_AND: PRECEDENCE_LOGICAL_AND,
         TOKEN_CONTAINS: PRECEDENCE_MEMBERSHIP,
         TOKEN_EQ: PRECEDENCE_RELATIONAL,
         TOKEN_GE: PRECEDENCE_RELATIONAL,
@@ -160,7 +162,7 @@ class Parser:
         TOKEN_LT: PRECEDENCE_RELATIONAL,
         TOKEN_NE: PRECEDENCE_RELATIONAL,
         TOKEN_NOT: PRECEDENCE_PREFIX,
-        TOKEN_OR: PRECEDENCE_LOGICAL,
+        TOKEN_OR: PRECEDENCE_LOGICAL_OR,
         TOKEN_RE: PRECEDENCE_RELATIONAL,
         TOKEN_RPAREN: PRECEDENCE_LOWEST,
     }
@@ -563,9 +565,9 @@ class Parser:
 
     def parse_regex(self, stream: TokenStream) -> FilterExpression:
         pattern = stream.current.value
+        flags = 0
         if stream.peek.kind == TOKEN_RE_FLAGS:
             stream.next_token()
-            flags = 0
             for flag in set(stream.current.value):
                 flags |= self.RE_FLAG_MAP[flag]
         return RegexLiteral(value=re.compile(pattern, flags))

--- a/jsonpath/selectors.py
+++ b/jsonpath/selectors.py
@@ -541,17 +541,17 @@ class ListSelector(JSONPathSelector):
         return hash((self.items, self.token))
 
     def resolve(self, matches: Iterable[JSONPathMatch]) -> Iterable[JSONPathMatch]:
-        _matches = list(matches)
-        for item in self.items:
-            yield from item.resolve(_matches)
+        for match_ in matches:
+            for item in self.items:
+                yield from item.resolve([match_])
 
     async def resolve_async(
         self, matches: AsyncIterable[JSONPathMatch]
     ) -> AsyncIterable[JSONPathMatch]:
-        _matches = [m async for m in matches]
-        for item in self.items:
-            async for match in item.resolve_async(_alist(_matches)):
-                yield match
+        async for match_ in matches:
+            for item in self.items:
+                async for m in item.resolve_async(_alist([match_])):
+                    yield m
 
 
 class Filter(JSONPathSelector):

--- a/tests/test_ietf.py
+++ b/tests/test_ietf.py
@@ -279,7 +279,7 @@ TEST_CASES = [
         description=("descendant segment - Multiple segments"),
         path="$.a..[0, 1]",
         data={"o": {"j": 1, "k": 2}, "a": [5, 3, [{"j": 4}, {"k": 6}]]},
-        want=[5, {"j": 4}, 3, {"k": 6}],
+        want=[5, 3, {"j": 4}, {"k": 6}],
     ),
     Case(
         description=("null semantics - Object value"),


### PR DESCRIPTION
Fix logical operator precedence in JSONPath filter expressions. `&&` should bind more tightly than `||`.

Fix bracketed selector list evaluation order. We now exhaust all matches for the first item before moving on to the next item.