### PR TITLE
Fix filter query existence tests in logical expressions

### DIFF
--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -75,6 +75,18 @@ TEST_CASES = [
         data={"some": {"thing": "else", "foo": {"bar": "baz"}}},
         want=["some", "thing", "foo", "bar"],
     ),
+    Case(
+        description="logical expr existence tests",
+        path="$[?@.a && @.b]",
+        data=[{"a": True, "b": False}],
+        want=[{"a": True, "b": False}],
+    ),
+    Case(
+        description="logical expr existence tests, alternate and",
+        path="$[?@.a and @.b]",
+        data=[{"a": True, "b": False}],
+        want=[{"a": True, "b": False}],
+    ),
 ]
 
 


### PR DESCRIPTION
Don't unwrap singular node lists in logical expressions. Fixes #57.