### PR TITLE
JSONPath syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Python JSONPath Change Log
 
+## Version 1.1.2 (unreleased)
+
+- Fixed handling of JSONPath literals in filter expressions. We now raise a `JSONPathSyntaxError` if a filter expression literal is not part of a comparison or function expression. See [jsonpath-compliance-test-suite#81](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/81).
+
 ## Version 1.1.1
 
 **Fixes**

--- a/jsonpath/__about__.py
+++ b/jsonpath/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present James Prior <jamesgr.prior@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -34,6 +34,11 @@ SKIP = {
     "basic, no leading whitespace": "flexible whitespace policy",
     "basic, no trailing whitespace": "flexible whitespace policy",
     "basic, bald descendant segment": "almost has a consensus",
+    "filter, index segment on object, selects nothing": "flexible selector policy",
+    "functions, match, dot matcher on \\u2028": "standard library re policy",
+    "functions, match, dot matcher on \\u2029": "standard library re policy",
+    "functions, search, dot matcher on \\u2028": "standard library re policy",
+    "functions, search, dot matcher on \\u2029": "standard library re policy",
     "functions, match, filter, match function, unicode char class, uppercase": "\\p not supported",  # noqa: E501
     "functions, match, filter, match function, unicode char class negated, uppercase": "\\P not supported",  # noqa: E501
     "functions, search, filter, search function, unicode char class, uppercase": "\\p not supported",  # noqa: E501

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -44,7 +44,6 @@ class FilterLiteralTestCase(NamedTuple):
     query: str
 
 
-# TODO: add these to the CTS?
 BAD_FILTER_LITERAL_TEST_CASES: List[FilterLiteralTestCase] = [
     FilterLiteralTestCase("just true", "$[?true]"),
     FilterLiteralTestCase("just string", "$[?'foo']"),


### PR DESCRIPTION
This PR adds more error handling to the JSONPath parser. We now catch unbalanced parentheses and force filter expression literals to be compared.

Depends on https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/81.