### PR TITLE
Allow `Query.select()` to accept precompiled paths

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -166,12 +166,16 @@ for product in query("$..products.*", data).values():
 {'title': 'Beanie', 'description': 'Winter running hat.', 'price': 9.0}
 ```
 
-We can select nested values too.
+We can select nested values too, and arguments to `select()` can be pre-compiled paths.
 
 ```python
+import jsonpath
+
 # ...
 
-for product in query("$..products.*", data).select("title", "social.shares"):
+projection = (jsonpath.compile("title"), jsonpath.compile("social.shares"))
+
+for product in jsonpath.query("$..products.*", data).select(*projection):
     print(product)
 ```
 

--- a/tests/test_query_projection.py
+++ b/tests/test_query_projection.py
@@ -159,3 +159,11 @@ def test_sparse_array_selection() -> None:
     assert list(it) == [
         {"categories": [{"products": [{"title": "Beanie", "social": {"shares": 7}}]}]}
     ]
+
+
+def test_pre_compiled_select_many() -> None:
+    expr = "$.*"
+    data = [{"a": 1, "b": 1, "c": 1}, {"a": 2, "b": 2, "c": 2}, {"b": 3, "a": 3}]
+    projection = (jsonpath.compile("a"), "c")
+    it = jsonpath.query(expr, data).select(*projection)
+    assert list(it) == [{"a": 1, "c": 1}, {"a": 2, "c": 2}, {"a": 3}]


### PR DESCRIPTION
`Query.select()` now accepts precompiled JSONPaths as well as strings.