### PR TITLE
Skip tests for invalid `\u` escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Compliance**
 
-- Skipped tests for invalid escape sequences. The JSONPath spec is more strict than Python's JSON decoder when it comes to parsing `\u` escape sequences in string literals. We are adopting a policy of least surprise. That is, most people will expect the JSONPath parser to behave the same as Python's JSON parser. See [jsonpath-compliance-test-suite #87](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87).
+- Skipped tests for invalid escape sequences. The JSONPath spec is more strict than Python's JSON decoder when it comes to parsing `\u` escape sequences in string literals. We are adopting a policy of least surprise. The assertion is that most people will expect the JSONPath parser to behave the same as Python's JSON parser. See [jsonpath-compliance-test-suite #87](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87).
 
 **Features**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed handling of JSONPath literals in filter expressions. We now raise a `JSONPathSyntaxError` if a filter expression literal is not part of a comparison, membership or function expression. See [jsonpath-compliance-test-suite#81](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/81).
 
+**Compliance**
+
+- Skipped tests for invalid escape sequences. The JSONPath spec is more strict than Python's JSON decoder when it comes to parsing `\u` escape sequences in string literals. We are adopting a policy of least surprise. That is, most people will expect the JSONPath parser to behave the same as Python's JSON parser. See [jsonpath-compliance-test-suite #87](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87).
+
 **Features**
 
 - Allow JSONPath filter expression membership operators (`contains` and `in`) to operate on object/mapping data as well as arrays/sequences. See [#55](https://github.com/jg-rp/python-jsonpath/issues/55).

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -213,6 +213,7 @@ And this is a list of areas where we deviate from [RFC 9535](https://datatracker
 - By default, `and` is equivalent to `&&` and `or` is equivalent to `||`.
 - `none` and `nil` are aliases for `null`.
 - `null` (and its aliases), `true` and `false` can start with an upper or lower case letter.
+- We don't treat some invalid `\u` escape sequences in quoted name selectors and string literals as an error. We match the behavior of the JSON decoder in Python's standard library, which is less strict than RFC 9535.
 
 And this is a list of features that are uncommon or unique to Python JSONPath.
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -44,6 +44,11 @@ SKIP = {
     "functions, search, filter, search function, unicode char class, uppercase": "\\p not supported",  # noqa: E501
     "functions, search, filter, search function, unicode char class negated, uppercase": "\\P not supported",  # noqa: E501
     "filter, equals number, decimal fraction, no fractional digit": "TODO",
+    "name selector, double quotes, single high surrogate": "expected behavior policy",
+    "name selector, double quotes, single low surrogate": "expected behavior policy",
+    "name selector, double quotes, high high surrogate": "expected behavior policy",
+    "name selector, double quotes, low low surrogate": "expected behavior policy",
+    "name selector, double quotes, surrogate non-surrogate": "expected behavior policy",
     "whitespace, selectors, space between dot and name": "flexible whitespace policy",  # noqa: E501
     "whitespace, selectors, newline between dot and name": "flexible whitespace policy",  # noqa: E501
     "whitespace, selectors, tab between dot and name": "flexible whitespace policy",  # noqa: E501


### PR DESCRIPTION
This PR updates the CTS and skips some test cases.

The JSONPath spec is more strict than Python's JSON decoder when it comes to parsing `\u` escape sequences in string literals (including name selectors). We are adopting a policy of least surprise. The assertion is that most people will expect the JSONPath parser to behave the same as Python's JSON parser. 

See [jsonpath-compliance-test-suite #87](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/pull/87).

Also see [jsonpath-rfc9525](https://github.com/jg-rp/python-jsonpath-rfc9535), an implementation of JSONPath for Python that follows RFC 9535 strictly. 