### PR TITLE
Fix the string representation of regex literals. Fixes #70.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Python JSONPath Change Log
 
+## Version 1.2.1 (unreleased)
+
+**Fixes**
+
+- Fixed the string representation regex literals in filter expressions. See [issue #70](https://github.com/jg-rp/python-jsonpath/issues/70).
+
 ## Version 1.2.0
 
 **Fixes**

--- a/jsonpath/__about__.py
+++ b/jsonpath/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present James Prior <jamesgr.prior@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/jsonpath/filter.py
+++ b/jsonpath/filter.py
@@ -243,8 +243,7 @@ class RegexLiteral(Literal[Pattern[str]]):
             if self.value.flags & flag:
                 flags.append(ch)
 
-        pattern = re.sub(r"\\(.)", r"\1", self.value.pattern)
-        return f"/{pattern}/{''.join(flags)}"
+        return f"/{self.value.pattern}/{''.join(flags)}"
 
 
 class ListLiteral(FilterExpression):

--- a/tests/test_fluent_api.py
+++ b/tests/test_fluent_api.py
@@ -4,7 +4,7 @@ import pytest
 
 from jsonpath import JSONPathMatch
 from jsonpath import JSONPointer
-from jsonpath import compile
+from jsonpath import compile  # noqa: A004
 from jsonpath import query
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -210,6 +210,11 @@ TEST_CASES = [
         path=r"$[?@ =~ /\\d/]",
         want="$[?@ =~ /\\\\d/]",
     ),
+    Case(
+        description="match function",
+        path=r"$[?match(@, '\\d')]",
+        want='$[?match(@, "\\\\d")]',
+    ),
 ]
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -200,6 +200,16 @@ TEST_CASES = [
         path="$[?!(@.a && !@.b)]",
         want="$[?!(@['a'] && !@['b'])]",
     ),
+    Case(
+        description="issue 70",
+        path=r"$[?@ =~ /\d/]",
+        want="$[?@ =~ /\\d/]",
+    ),
+    Case(
+        description="escaped slash in regex literal",
+        path=r"$[?@ =~ /\\d/]",
+        want="$[?@ =~ /\\\\d/]",
+    ),
 ]
 
 

--- a/tests/test_re.py
+++ b/tests/test_re.py
@@ -39,6 +39,12 @@ TEST_CASES = [
         data={"some": [{"thing": "foO"}]},
         want=[{"thing": "foO"}],
     ),
+    Case(
+        description="escaped slash",
+        path="$.some[?(@.thing =~ /fo\\\\[a-z]/)]",
+        data={"some": [{"thing": "fo\\b"}]},
+        want=[{"thing": "fo\\b"}],
+    ),
 ]
 
 


### PR DESCRIPTION
Were were deliberately clobbering backslash characters in the string representation of regex literals.

Not sure why we'd ever want to do this. 🤔 