### PR TITLE
Fix bare name selectors that start with a reserved word

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Python JSONPath Change Log
 
+## Version 1.2.2 (unreleased)
+
+**Fixes**
+
+- Fixed parsing of bare name selectors that start with a reserved word. See [issue #72](https://github.com/jg-rp/python-jsonpath/issues/72).
+
 ## Version 1.2.1
 
 **Fixes**

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -42,6 +42,8 @@ $.categories[0][name]
 $.categories[0]['name']
 ```
 
+By default, `or`, `and`, `in`, `true`, `True`, `false`, `False`, `nil`, `Nil`, `null`, `Null`, `none`, `None`, `contains`, `undefined`, and `missing` are considered _reserved words_. In some cases you will need to use quoted property/name selector syntax if you're selecting a name that matches any of these words exactly. For example, `["and"]`.
+
 ### Array indices (`[0]` or `[-1]`)
 
 Select an item from an array by its index. Indices are zero-based and enclosed in brackets. If the index is negative, items are selected from the end of the array. Considering example data from the top of this page, the following examples are equivalent.

--- a/jsonpath/__about__.py
+++ b/jsonpath/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present James Prior <jamesgr.prior@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/jsonpath/lex.py
+++ b/jsonpath/lex.py
@@ -88,13 +88,13 @@ class Lexer:
     key_pattern = r"[\u0080-\uFFFFa-zA-Z_][\u0080-\uFFFFa-zA-Z0-9_-]*"
 
     # `not` or !
-    logical_not_pattern = r"(?:not|!)"
+    logical_not_pattern = r"(?:not\b)|!"
 
     # && or `and`
-    logical_and_pattern = r"(?:&&|and)"
+    logical_and_pattern = r"&&|(?:and\b)"
 
     # || or `or`
-    logical_or_pattern = r"(?:\|\||or)"
+    logical_or_pattern = r"\|\||(?:or\b)"
 
     def __init__(self, *, env: JSONPathEnvironment) -> None:
         self.env = env
@@ -153,15 +153,15 @@ class Lexer:
             ],
             (TOKEN_WILD, r"\*"),
             (TOKEN_FILTER, r"\?"),
-            (TOKEN_IN, r"in"),
-            (TOKEN_TRUE, r"[Tt]rue"),
-            (TOKEN_FALSE, r"[Ff]alse"),
-            (TOKEN_NIL, r"[Nn]il"),
-            (TOKEN_NULL, r"[Nn]ull"),
-            (TOKEN_NONE, r"[Nn]one"),
-            (TOKEN_CONTAINS, r"contains"),
-            (TOKEN_UNDEFINED, r"undefined"),
-            (TOKEN_MISSING, r"missing"),
+            (TOKEN_IN, r"in\b"),
+            (TOKEN_TRUE, r"[Tt]rue\b"),
+            (TOKEN_FALSE, r"[Ff]alse\b"),
+            (TOKEN_NIL, r"[Nn]il\b"),
+            (TOKEN_NULL, r"[Nn]ull\b"),
+            (TOKEN_NONE, r"[Nn]one\b"),
+            (TOKEN_CONTAINS, r"contains\b"),
+            (TOKEN_UNDEFINED, r"undefined\b"),
+            (TOKEN_MISSING, r"missing\b"),
             (TOKEN_LIST_START, r"\["),
             (TOKEN_RBRACKET, r"]"),
             (TOKEN_COMMA, r","),

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -127,6 +127,30 @@ TEST_CASES = [
             }
         ],
     ),
+    Case(
+        description="issue 72, orders",
+        path="orders",
+        data={"orders": [1, 2, 3]},
+        want=[[1, 2, 3]],
+    ),
+    Case(
+        description="issue 72, andy",
+        path="andy",
+        data={"andy": [1, 2, 3]},
+        want=[[1, 2, 3]],
+    ),
+    Case(
+        description="quoted reserved word, and",
+        path="['and']",
+        data={"and": [1, 2, 3]},
+        want=[[1, 2, 3]],
+    ),
+    Case(
+        description="quoted reserved word, or",
+        path="['or']",
+        data={"or": [1, 2, 3]},
+        want=[[1, 2, 3]],
+    ),
 ]
 
 

--- a/tests/test_lex.py
+++ b/tests/test_lex.py
@@ -1375,6 +1375,85 @@ TEST_CASES = [
             Token(kind=TOKEN_RBRACKET, value="]", index=9, path="$.thing[~]"),
         ],
     ),
+    Case(
+        description="implicit root selector, name selector starts with `and`",
+        path="anderson",
+        want=[
+            Token(kind=TOKEN_BARE_PROPERTY, value="anderson", index=0, path="anderson"),
+        ],
+    ),
+    Case(
+        description="implicit root selector, name selector starts with `or`",
+        path="order",
+        want=[
+            Token(kind=TOKEN_BARE_PROPERTY, value="order", index=0, path="order"),
+        ],
+    ),
+    Case(
+        description="implicit root selector, name selector starts with `true`",
+        path="trueblue",
+        want=[
+            Token(kind=TOKEN_BARE_PROPERTY, value="trueblue", index=0, path="trueblue"),
+        ],
+    ),
+    Case(
+        description="implicit root selector, name selector starts with `false`",
+        path="falsehood",
+        want=[
+            Token(
+                kind=TOKEN_BARE_PROPERTY, value="falsehood", index=0, path="falsehood"
+            ),
+        ],
+    ),
+    Case(
+        description="implicit root selector, name selector starts with `not`",
+        path="nottingham",
+        want=[
+            Token(
+                kind=TOKEN_BARE_PROPERTY, value="nottingham", index=0, path="nottingham"
+            ),
+        ],
+    ),
+    Case(
+        description="implicit root selector, name selector starts with `null`",
+        path="nullable",
+        want=[
+            Token(kind=TOKEN_BARE_PROPERTY, value="nullable", index=0, path="nullable"),
+        ],
+    ),
+    Case(
+        description="implicit root selector, name selector starts with `none`",
+        path="nonexpert",
+        want=[
+            Token(
+                kind=TOKEN_BARE_PROPERTY, value="nonexpert", index=0, path="nonexpert"
+            ),
+        ],
+    ),
+    Case(
+        description="implicit root selector, name selector starts with `undefined`",
+        path="undefinedness",
+        want=[
+            Token(
+                kind=TOKEN_BARE_PROPERTY,
+                value="undefinedness",
+                index=0,
+                path="undefinedness",
+            ),
+        ],
+    ),
+    Case(
+        description="implicit root selector, name selector starts with `missing`",
+        path="missingly",
+        want=[
+            Token(
+                kind=TOKEN_BARE_PROPERTY,
+                value="missingly",
+                index=0,
+                path="missingly",
+            ),
+        ],
+    ),
 ]
 
 


### PR DESCRIPTION
Fix bare name selectors that start with a reserved word. See #72.