### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,13 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
-          - os: macos-latest
-            python-version: "3.7"
-          - os: windows-latest
-            python-version: "3.7"
           - os: macos-latest
             python-version: "3.8"
           - os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed parsing of bare name selectors that start with a reserved word. See [issue #72](https://github.com/jg-rp/python-jsonpath/issues/72).
 
+**Changes**
+
+- We're dropped support for Python 3.7, which was end of life in June 2023.
+
 ## Version 1.2.1
 
 **Fixes**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "python-jsonpath"
 description = 'JSONPath, JSON Pointer and JSON Patch for Python.'
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = "MIT"
 keywords = []
 authors = [{ name = "James Prior", email = "jamesgr.prior@gmail.com" }]
@@ -15,7 +15,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -67,7 +66,7 @@ lint = "ruff check ."
 typing = "mypy"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311", "312", "pypy38", "pypy39"]
+python = ["38", "39", "310", "311", "312", "pypy38", "pypy39"]
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args}"


### PR DESCRIPTION
Python 3.7 was end of life in June 2023 and is not available on the latest Ubuntu GitHub action runner.