### PR TITLE
Fix lint checks and patch targets that look like ints

### DIFF
--- a/jsonpath/filter.py
+++ b/jsonpath/filter.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from .path import JSONPath
     from .selectors import FilterContext
 
-# ruff: noqa: D102
+# ruff: noqa: D102, PLW1641
 
 
 class FilterExpression(ABC):

--- a/jsonpath/function_extensions/arguments.py
+++ b/jsonpath/function_extensions/arguments.py
@@ -1,4 +1,5 @@
 """Class-based function extension base."""
+
 import inspect
 from typing import TYPE_CHECKING
 from typing import Any
@@ -26,7 +27,7 @@ def validate(
     params = list(inspect.signature(func).parameters.values())
 
     # Keyword only params are not supported
-    if len([p for p in params if p.kind in (p.KEYWORD_ONLY, p.VAR_KEYWORD)]):
+    if [p for p in params if p.kind in (p.KEYWORD_ONLY, p.VAR_KEYWORD)]:
         raise JSONPathTypeError(
             f"function {token.value!r} requires keyword arguments",
             token=token,

--- a/jsonpath/patch.py
+++ b/jsonpath/patch.py
@@ -74,7 +74,7 @@ class OpAdd(Op):
             else:
                 parent.insert(int(target), self.value)
         elif isinstance(parent, MutableMapping):
-            parent[target] = self.value
+            parent[str(target)] = self.value
         else:
             raise JSONPatchError(
                 f"unexpected operation on {parent.__class__.__name__!r}"
@@ -183,7 +183,7 @@ class OpRemove(Op):
         elif isinstance(parent, MutableMapping):
             if obj is UNDEFINED:
                 raise JSONPatchError("can't remove nonexistent property")
-            del parent[self.path.parts[-1]]
+            del parent[str(self.path.parts[-1])]
         else:
             raise JSONPatchError(
                 f"unexpected operation on {parent.__class__.__name__!r}"
@@ -221,7 +221,7 @@ class OpReplace(Op):
         elif isinstance(parent, MutableMapping):
             if obj is UNDEFINED:
                 raise JSONPatchError("can't replace nonexistent property")
-            parent[self.path.parts[-1]] = self.value
+            parent[str(self.path.parts[-1])] = self.value
         else:
             raise JSONPatchError(
                 f"unexpected operation on {parent.__class__.__name__!r}"
@@ -259,7 +259,7 @@ class OpMove(Op):
         if isinstance(source_parent, MutableSequence):
             del source_parent[int(self.source.parts[-1])]
         if isinstance(source_parent, MutableMapping):
-            del source_parent[self.source.parts[-1]]
+            del source_parent[str(self.source.parts[-1])]
 
         dest_parent, _ = self.dest.resolve_parent(data)
 
@@ -270,7 +270,7 @@ class OpMove(Op):
         if isinstance(dest_parent, MutableSequence):
             dest_parent.insert(int(self.dest.parts[-1]), source_obj)
         elif isinstance(dest_parent, MutableMapping):
-            dest_parent[self.dest.parts[-1]] = source_obj
+            dest_parent[str(self.dest.parts[-1])] = source_obj
         else:
             raise JSONPatchError(
                 f"unexpected operation on {dest_parent.__class__.__name__!r}"
@@ -312,7 +312,7 @@ class OpCopy(Op):
         if isinstance(dest_parent, MutableSequence):
             dest_parent.insert(int(self.dest.parts[-1]), copy.deepcopy(source_obj))
         elif isinstance(dest_parent, MutableMapping):
-            dest_parent[self.dest.parts[-1]] = copy.deepcopy(source_obj)
+            dest_parent[str(self.dest.parts[-1])] = copy.deepcopy(source_obj)
         else:
             raise JSONPatchError(
                 f"unexpected operation on {dest_parent.__class__.__name__!r}"

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -485,6 +485,9 @@ class RelativeJSONPointer:
     def __eq__(self, __value: object) -> bool:
         return isinstance(__value, RelativeJSONPointer) and str(self) == str(__value)
 
+    def __hash__(self) -> int:
+        return hash((self.origin, self.index, self.pointer))
+
     def _parse(
         self,
         rel: str,

--- a/tests/test_json_patch.py
+++ b/tests/test_json_patch.py
@@ -268,3 +268,8 @@ def test_non_standard_addap_op() -> None:
     # Index 7 is out of range and would raises a JSONPatchError with the `add` op.
     patch = JSONPatch().addap(path="/foo/7", value=99)
     assert patch.apply({"foo": [1, 2, 3]}) == {"foo": [1, 2, 3, 99]}
+
+
+def test_add_to_mapping_with_int_key() -> None:
+    patch = JSONPatch().add(path="/1", value=99)
+    assert patch.apply({"foo": 1}) == {"foo": 1, "1": 99}


### PR DESCRIPTION
This PR fixes some lint checks and ensures JSON Patch targets are strings if they are operating on a mapping.

Previously, 

```python
assert JSONPatch().add(path="/1", value=99) patch.apply({"foo": 1}) == {"foo": 1, 1: 99}
```

now, the new `1` is a string:

```python
assert JSONPatch().add(path="/1", value=99) patch.apply({"foo": 1}) == {"foo": 1, "1": 99}
```