### PR TITLE
Refactor `JSONPointer` and improve docs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,18 @@ jobs:
             python-version: "3.8"
           - os: windows-latest
             python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.11"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -20,9 +20,6 @@ Each of the following exceptions has a `token` property, referencing the [`Token
 ::: jsonpath.JSONPointerError
     handler: python
 
-::: jsonpath.JSONPointerEncodeError
-    handler: python
-
 ::: jsonpath.JSONPointerResolutionError
     handler: python
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -173,7 +173,18 @@ if match:
 
 **_New in version 0.8.0_**
 
-Resolve a JSON Pointer ([RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901)) against some data. A JSON Pointer references a single object on a specific "path" in a JSON document. Here, _pointer_ can be a string representation of a JSON Pointer or a list of parts that make up a pointer. _data_ can be a file-like object or string containing JSON formatted data, or equivalent Python objects.
+Resolves a JSON Pointer ([RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901)) against a JSON document, returning the value located at the specified path.
+
+The `pointer` argument can be either:
+
+- A string representation of a JSON Pointer (e.g., `"/foo/bar/0"`)
+- A list of unescaped pointer segments (e.g., `["foo", "bar", "0"]`)
+
+The `data` argument can be:
+
+- A Python data structure (`dict`, `list`, etc.)
+- A JSON-formatted string
+- A file-like object containing JSON
 
 ```python
 from jsonpath import pointer
@@ -206,7 +217,15 @@ jane_score = pointer.resolve(["users", 3, "score"], data)
 print(jane_score)  # 55
 ```
 
-If the pointer can't be resolved against the target JSON document - due to missing keys/properties or out of range indices - a `JSONPointerIndexError`, `JSONPointerKeyError` or `JSONPointerTypeError` will be raised, each of which inherit from `JSONPointerResolutionError`. A default value can be given, which will be returned in the event of a `JSONPointerResolutionError`.
+If the pointer cannot be resolved against the target JSON data — due to a missing key, an out-of-range index, or an unexpected data type — an exception will be raised:
+
+- `JSONPointerKeyError` – when a referenced key is missing from an object
+- `JSONPointerIndexError` – when an array index is out of bounds
+- `JSONPointerTypeError` – when a path segment expects the wrong type (e.g., indexing into a non-array)
+
+All of these exceptions are subclasses of `JSONPointerResolutionError`.
+
+You can optionally provide a `default` value to `resolve()`, which will be returned instead of raising an error if the pointer cannot be resolved.
 
 ```python
 from jsonpath import pointer

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,9 +4,22 @@ This page gets you started using JSONPath, JSON Pointer and JSON Patch wih Pytho
 
 ## `findall(path, data)`
 
-Find all objects matching a JSONPath with [`jsonpath.findall()`](api.md#jsonpath.JSONPathEnvironment.findall). It takes, as arguments, a JSONPath string and some _data_ object. It always returns a list of objects selected from _data_, never a scalar value.
+Find all values matching a JSONPath expression using [`jsonpath.findall()`](api.md#jsonpath.JSONPathEnvironment.findall).
 
-_data_ can be a file-like object or string containing JSON formatted data, or a Python [`Mapping`](https://docs.python.org/3/library/collections.abc.html#collections.abc.Mapping) or [`Sequence`](https://docs.python.org/3/library/collections.abc.html#collections.abc.Sequence), like a dictionary or list. In this example we select user names from a dictionary containing a list of user dictionaries.
+This function takes two arguments:
+
+- `path`: a JSONPath expression as a string (e.g., `"$.users[*].name"`)
+- `data`: the JSON document to query
+
+It always returns a **list** of matched values, even if the path resolves to a single result or nothing at all.
+
+The `data` argument can be:
+
+- A Python [`Mapping`](https://docs.python.org/3/library/collections.abc.html#collections.abc.Mapping) (e.g., `dict`) or [`Sequence`](https://docs.python.org/3/library/collections.abc.html#collections.abc.Sequence) (e.g., `list`)
+- A JSON-formatted string
+- A file-like object containing JSON
+
+For example, the following query extracts all user names from a dictionary containing a list of user objects:
 
 ```python
 import jsonpath

--- a/jsonpath/__init__.py
+++ b/jsonpath/__init__.py
@@ -10,7 +10,6 @@ from .exceptions import JSONPathIndexError
 from .exceptions import JSONPathNameError
 from .exceptions import JSONPathSyntaxError
 from .exceptions import JSONPathTypeError
-from .exceptions import JSONPointerEncodeError
 from .exceptions import JSONPointerError
 from .exceptions import JSONPointerIndexError
 from .exceptions import JSONPointerKeyError
@@ -52,7 +51,6 @@ __all__ = (
     "JSONPathSyntaxError",
     "JSONPathTypeError",
     "JSONPointer",
-    "JSONPointerEncodeError",
     "JSONPointerError",
     "JSONPointerIndexError",
     "JSONPointerKeyError",

--- a/jsonpath/env.py
+++ b/jsonpath/env.py
@@ -99,7 +99,7 @@ class JSONPathEnvironment:
         intersection_token (str): The pattern used as the intersection operator.
             Defaults to `"&"`.
         key_token (str): The pattern used to identify the current key or index when
-            filtering a, mapping or sequence. Defaults to `"#"`.
+            filtering a mapping or sequence. Defaults to `"#"`.
         keys_selector_token (str): The pattern used as the "keys" selector. Defaults to
             `"~"`.
         lexer_class: The lexer to use when tokenizing path strings.

--- a/jsonpath/exceptions.py
+++ b/jsonpath/exceptions.py
@@ -1,4 +1,5 @@
 """JSONPath exceptions."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -80,10 +81,6 @@ class JSONPointerError(Exception):
     """Base class for all JSON Pointer errors."""
 
 
-class JSONPointerEncodeError(JSONPointerError):
-    """An exception raised when a JSONPathMatch can't be encoded to a JSON Pointer."""
-
-
 class JSONPointerResolutionError(JSONPointerError):
     """Base exception for those that can be raised during pointer resolution."""
 
@@ -145,7 +142,7 @@ class JSONPatchTestFailure(JSONPatchError):  # noqa: N818
 def _truncate_message(value: str, num: int, end: str = "...") -> str:
     if len(value) < num:
         return value
-    return f"{value[:num-len(end)]}{end}"
+    return f"{value[: num - len(end)]}{end}"
 
 
 def _truncate_words(val: str, num: int, end: str = "...") -> str:

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -115,7 +115,7 @@ class JSONPointer:
         try:
             index = int(s)
             if index < self.min_int_index or index > self.max_int_index:
-                raise JSONPointerIndexError("index out of range")
+                raise JSONPointerError("index out of range")
             return index
         except ValueError:
             return s

--- a/jsonpath/pointer.py
+++ b/jsonpath/pointer.py
@@ -140,15 +140,14 @@ class JSONPointer:
             # Try a string repr of the index-like item as a mapping key.
             return self._getitem(obj, str(key))
 
-        # Handle non-standard keys/property selector/pointer.
+        # Handle non-standard key/property selector/pointer.
         #
-        # For the benefit of `RelativeJSONPointer.to()`, treat keys starting with a `#`
-        # as a "key pointer". If `key[1:]` is a key in `obj`, return the key.
+        # For the benefit of `RelativeJSONPointer.to()` and `JSONPathMatch.pointer()`,
+        # treat keys starting with a `#` or `~` as a "key pointer". If `key[1:]` is a
+        # key in `obj`, return the key.
         #
-        # Note that is a key with a leading `#` exists in `obj`, it will have been
+        # Note that if a key with a leading `#`/`~` exists in `obj`, it will have been
         # handled by `_getitem`.
-        #
-        # TODO: Same goes for `~`
         if (
             isinstance(key, str)
             and isinstance(obj, Mapping)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.details
 
 extra_css:
   - css/style.css

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -1,4 +1,5 @@
 """JSONPointer test cases."""
+
 from io import StringIO
 from typing import List
 from typing import Union
@@ -261,7 +262,7 @@ def test_join_pointers_with_slash() -> None:
     assert str(pointer / "/bar") == "/bar"
 
     with pytest.raises(TypeError):
-        pointer / 0
+        pointer / 0  # type: ignore
 
 
 def test_join_pointers() -> None:
@@ -297,6 +298,15 @@ def test_non_standard_index_pointer() -> None:
     assert JSONPointer("/foo/bar/#1").resolve(data) == 1
     with pytest.raises(JSONPointerIndexError):
         JSONPointer("/foo/bar/#9").resolve(data)
+
+
+def test_non_standard_index_pointer_with_leading_zero() -> None:
+    data = {"foo": {"bar": [1, 2, 3], "#baz": "hello"}}
+    with pytest.raises(JSONPointerTypeError):
+        JSONPointer("/foo/bar/#01").resolve(data)
+
+    with pytest.raises(JSONPointerTypeError):
+        JSONPointer("/foo/bar/#09").resolve(data)
 
 
 def test_trailing_slash() -> None:

--- a/tests/test_json_pointer.py
+++ b/tests/test_json_pointer.py
@@ -40,7 +40,7 @@ def test_resolve_with_default() -> None:
     assert pointer.resolve(data, default=None) is None
 
 
-def test_pointer_index_out_fo_range() -> None:
+def test_pointer_index_out_of_range() -> None:
     max_plus_one = JSONPointer.max_int_index + 1
     min_minus_one = JSONPointer.min_int_index - 1
 
@@ -307,6 +307,12 @@ def test_non_standard_index_pointer_with_leading_zero() -> None:
 
     with pytest.raises(JSONPointerTypeError):
         JSONPointer("/foo/bar/#09").resolve(data)
+
+
+def test_non_standard_index_pointer_to_non_array_object() -> None:
+    data = {"foo": {"bar": True, "#baz": "hello"}}
+    with pytest.raises(JSONPointerTypeError):
+        JSONPointer("/foo/bar/#1").resolve(data)
 
 
 def test_trailing_slash() -> None:


### PR DESCRIPTION
This PR refactors `JSONPointer._getitem()` and adds some comments regarding the non-standard syntax it supports. Hopefully it is now more readable and maintainable.

I've stopped short of moving and/or disabling non-standard syntax by default for now, as this would probably be a breaking change and require a major version bump.