### PR TITLE
Update CTS

### DIFF
--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -21,6 +21,7 @@ from ._cts_case import Case
 XFAIL_INVALID = {
     "basic, no leading whitespace",
     "basic, no trailing whitespace",
+    "basic, root node identifier in brackets without filter selector",
     "filter, equals number, invalid 00",
     "filter, equals number, invalid leading 0",
     "filter, true, incorrectly capitalized",


### PR DESCRIPTION
This PR updates the Compliance Test Suite sub module and skips "basic, root node identifier in brackets without filter selector" when not in strict mode.

The following test case from the CTS is skipped when our non-standard "singular query selector" is enabled.

```json
{
  "name": "root node identifier in brackets without filter selector",
  "selector": "$[$.a]",
  "invalid_selector": true
}
```

We don't skip it when `strict=True`.