### PR TITLE
Fix parsing of regex literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Python JSONPath Change Log
 
+## Version 2.0.2 (unreleased)
+
+**Fixes**
+
+- Fixed parsing of non-standard JSONPath regular expression literals containing an escaped solidus (`/`). This affected queries using the regex operator `=~`, like `$.some[?(@.thing =~ /fo\/[a-z]/)]`, not standard `match` and `search` functions. See [#124](https://github.com/jg-rp/python-jsonpath/issues/124).
+
 ## Version 2.0.1
 
 **Fixes**

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -616,6 +616,19 @@ list-literal        = "[" S literal *(S "," S literal) S "]"
 $..products[?(@.description =~ /.*trainers/i)]
 ```
 
+You can escape a solidus (`/`) with a reverse solidus (`\`).
+
+```
+$.some[?(@.thing =~ /fo\/[a-z]/)]
+```
+
+As a Python string literal, you'd need to double escape the reverse solidus or use a raw string literal.
+
+```python
+query = r"$.some[?(@.thing =~ /fo\/[a-z]/)]"
+query = "$.some[?(@.thing =~ /fo\\/[a-z]/)]"
+```
+
 ### Union and intersection operators
 
 The union or concatenation operator, `|`, combines matches from two or more paths.

--- a/jsonpath/__about__.py
+++ b/jsonpath/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present James Prior <jamesgr.prior@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/jsonpath/lex.py
+++ b/jsonpath/lex.py
@@ -113,7 +113,7 @@ class Lexer:
         )
 
         # /pattern/ or /pattern/flags
-        self.re_pattern = r"/(?P<G_RE>.+?)/(?P<G_RE_FLAGS>[aims]*)"
+        self.re_pattern = r"/(?P<G_RE>(?:(?!(?<!\\)/).)*)/(?P<G_RE_FLAGS>[aims]*)"
 
         # func(
         self.function_pattern = r"(?P<G_FUNC>[a-z][a-z_0-9]+)(?P<G_FUNC_PAREN>\()"

--- a/tests/regex_operator.json
+++ b/tests/regex_operator.json
@@ -25,10 +25,34 @@
       "tags": ["extra"]
     },
     {
-      "name": "regex literal, escaped slash",
+      "name": "regex literal, escaped backslash",
       "selector": "$.some[?(@.thing =~ /fo\\\\[a-z]/)]",
       "document": { "some": [{ "thing": "fo\\b" }] },
       "result": [{ "thing": "fo\\b" }],
+      "result_paths": ["$['some'][0]"],
+      "tags": ["extra"]
+    },
+    {
+      "name": "regex literal, escaped slash",
+      "selector": "$.some[?(@.thing =~ /fo\\/[a-z]/)]",
+      "document": { "some": [{ "thing": "fo/b" }] },
+      "result": [{ "thing": "fo/b" }],
+      "result_paths": ["$['some'][0]"],
+      "tags": ["extra"]
+    },
+    {
+      "name": "regex literal, escaped asterisk",
+      "selector": "$.some[?(@.thing =~ /fo\\*[a-z]/)]",
+      "document": { "some": [{ "thing": "fo*b" }] },
+      "result": [{ "thing": "fo*b" }],
+      "result_paths": ["$['some'][0]"],
+      "tags": ["extra"]
+    },
+    {
+      "name": "regex literal, escaped dot",
+      "selector": "$.some[?(@.thing =~ /fo\\.[a-z]/)]",
+      "document": { "some": [{ "thing": "fo.b" }] },
+      "result": [{ "thing": "fo.b" }],
       "result_paths": ["$['some'][0]"],
       "tags": ["extra"]
     }

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -115,3 +115,19 @@ def test_issue_117() -> None:
     data = {"foo": ["bar", "baz"]}
     with pytest.raises(JSONPatchError):
         patch.apply(data)
+
+
+def test_issue_124() -> None:
+    query_raw = r"$[?@type =~ /studio\/material\/.*/]"
+    query = "$[?@type =~ /studio\\/material\\/.*/]"
+
+    data = [
+        {"type": "studio/material/a"},
+        {"type": "studio/material/b"},
+        {"type": "studio foo"},
+    ]
+
+    want = [{"type": "studio/material/a"}, {"type": "studio/material/b"}]
+
+    assert findall(query, data) == want
+    assert findall(query_raw, data) == want


### PR DESCRIPTION
This PR fixes parsing of JSONPath regular expression literals containing an escaped solidus (`/`).

See #124.